### PR TITLE
Autocreate worker objects when new users are registered.

### DIFF
--- a/orchestra/__init__.py
+++ b/orchestra/__init__.py
@@ -1,0 +1,2 @@
+# Make sure our signal receivers get registered.
+from orchestra import signals  # noqa

--- a/orchestra/signals.py
+++ b/orchestra/signals.py
@@ -1,0 +1,9 @@
+from django.dispatch import receiver
+from registration.signals import user_registered
+
+from orchestra.models import Worker
+
+
+@receiver(user_registered)
+def add_worker_for_new_users(sender, user, request, **kwargs):
+    Worker.objects.create(user=user)


### PR DESCRIPTION
This uses a `user_registered` signal provided by django-registration-redux.

It doesn't yet handle slack usernames--they still need to be added through the admin.
