### PR TITLE
Incorporate optional user hijack

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -104,6 +104,9 @@ Alternatively, just make sure to add the following code inside the
     url(r'^orchestra/accounts/',
         include('registration.backends.default.urls')),
 
+    # Optionally include these routes to enable user hijack functionality.
+    url(r'^orchestra/switch/', include('hijack.urls')),
+
     # Logout then login is not available as a standard django
     # registration route.
     url(r'^orchestra/accounts/logout_then_login/$',

--- a/example_project/example_project/orchestra_settings.py
+++ b/example_project/example_project/orchestra_settings.py
@@ -43,6 +43,8 @@ def setup_orchestra(settings_module_name):
         'orchestra',
         'beanstalk_dispatch',
         'registration',
+        'hijack',
+        'compat'
     )
 
     settings.STATICFILES_FINDERS += (
@@ -89,6 +91,10 @@ def setup_orchestra(settings_module_name):
     # Orchestra Registration setings
     settings.ACCOUNT_ACTIVATION_DAYS = 7  # One-week activation window
     settings.REGISTRATION_AUTO_LOGIN = True  # Automatically log the user in.
+
+    # Prevent hijack buttons from displaying in admin (otherwise, hijack can't
+    # be disabled by excluding the relevant URLs)
+    settings.SHOW_HIJACKUSER_IN_ADMIN = False
 
     # API Authentication
     #####################

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -63,6 +63,8 @@ TEMPLATES = [
         'OPTIONS': {
             'context_processors': [
                 'django.template.context_processors.debug',
+                # Allows access to request object in templates; currently used
+                # for displaying hijack notification
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',

--- a/example_project/example_project/urls.py
+++ b/example_project/example_project/urls.py
@@ -21,6 +21,9 @@ urlpatterns = [
     url(r'^orchestra/accounts/',
         include('registration.backends.default.urls')),
 
+    # Optionally include these routes to enable user hijack functionality.
+    url(r'^orchestra/switch/', include('hijack.urls')),
+
     # Logout then login is not available as a standard django
     # registration route.
     url(r'^orchestra/accounts/logout_then_login/$',

--- a/orchestra/static/orchestra/common/css/base.scss
+++ b/orchestra/static/orchestra/common/css/base.scss
@@ -65,6 +65,16 @@ a.logo {
   }
 }
 
+#hijacked-warning {
+  left: 25%;
+  width: 50%;
+  border-radius: 0 0 5px 5px;
+  > span:last-child {
+    // Hack to override button container inline style
+    margin-right: 0 !important;
+  }
+}
+
 .section-panel {
   margin: $panel-button-margin;
   box-shadow: 0 1px 3px black;

--- a/orchestra/templates/orchestra/base.html
+++ b/orchestra/templates/orchestra/base.html
@@ -1,5 +1,6 @@
 {% load compress %}
 {% load staticfiles %}
+{% load hijack_tags %}
 
 <!DOCTYPE html>
 <html lang="en" ng-app="orchestra">
@@ -23,6 +24,7 @@
     <!-- Custom styles for this template -->
     <link rel="stylesheet" href="{% static 'orchestra/common/css/lib/style.css' %}">
     <link rel="stylesheet" href="{% static 'orchestra/common/css/lib/style-responsive.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
     <link rel="stylesheet" type="text/x-scss" href="{% static 'orchestra/common/css/orchestra.scss' %}">
     <link rel="stylesheet" href="{% static 'orchestra/common/components/quill/css/quill.snow.min.css' %}">
     <link rel="stylesheet" type="text/x-scss" href="{% static 'orchestra/common/components/quill/css/quill.scss' %}">
@@ -43,7 +45,7 @@
   </head>
 
   <body>
-
+  {{ request|hijackNotification }}
   <section id="container" >
     <!--header start-->
     <header class="header">

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ django-libsass==0.3
 slacker==0.7.0
 pandas==0.16.2
 python-dateutil==2.4.2
+django-hijack==1.0.9
 
 # Documentation requirements
 Sphinx==1.3.1


### PR DESCRIPTION
Adds optional [django-hijack](https://github.com/arteria/django-hijack/blob/master/README.md) functionality. This can be added to a project by specifying the correct URLs (e.g., `url(r'^orchestra/switch/', include('hijack.urls'))`) and by including `'django.core.context_processors.request'` in your list of template context_processors.
