### PR TITLE
Fix project details screen and migrate project start_datetime

### DIFF
--- a/orchestra/admin_views.py
+++ b/orchestra/admin_views.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import render
 from django.utils.encoding import force_text
 from django.utils.text import capfirst
+from django.utils.dateparse import parse_datetime
 from orchestra.models import Project
 from orchestra.orchestra_api import get_project_information
 
@@ -28,8 +28,7 @@ def project_details(request, project_id):
 
 
 def _prettify_project_details(project, tasks_data, steps):
-    project['start_datetime'] = datetime.strptime(project['start_datetime'],
-                                                  '%Y-%m-%dT%H:%M:%S.%fZ')
+    project['start_datetime'] = parse_datetime(project['start_datetime'])
 
     # Clean up the project_data dict's keys so they will display nicely
     url_regex = re.compile(r"url", re.IGNORECASE)
@@ -57,13 +56,11 @@ def _prettify_project_details(project, tasks_data, steps):
 
         task['step_description'] = step_description
         if 'start_datetime' in task:
-            task['start_datetime'] = (datetime.strptime(
-                task['start_datetime'], '%Y-%m-%dT%H:%M:%S.%fZ'))
+            task['start_datetime'] = parse_datetime(task['start_datetime'])
 
         # Assignment times need to be formatted more nicely
         for assignment in task.get('assignments', []):
-            new_datetime = datetime.strptime(assignment['start_datetime'],
-                                             '%Y-%m-%dT%H:%M:%S.%fZ')
+            new_datetime = parse_datetime(assignment['start_datetime'])
             assignment['start_datetime'] = new_datetime
 
         tasks.append(task)

--- a/orchestra/migrations/0020_auto_20151028_1559.py
+++ b/orchestra/migrations/0020_auto_20151028_1559.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orchestra', '0019_auto_20151022_1531'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='start_datetime',
+            field=models.DateTimeField(default=django.utils.timezone.now),
+        ),
+    ]

--- a/orchestra/models.py
+++ b/orchestra/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils import timezone
@@ -55,7 +54,7 @@ class Worker(models.Model):
             The worker's Slack username if Slack integration is enabled.
     """
     user = models.OneToOneField(User)
-    start_datetime = models.DateTimeField(default=datetime.now)
+    start_datetime = models.DateTimeField(default=timezone.now)
     slack_username = models.CharField(max_length=200, blank=True, null=True)
 
     def __str__(self):
@@ -140,12 +139,12 @@ class Project(models.Model):
     A project is a collection of tasks representing a workflow.
 
     Attributes:
+        start_datetime (datetime.datetime):
+            The time the project was created.
         status (orchestra.models.Project.Status):
             Represents whether the project is being actively worked on.
         workflow_slug (str):
             Identifies the workflow that the project represents.
-        start_datetime (datetime.datetime):
-            The time the project was created.
         priority (int):
             Represents the relative priority of the project.
         task_class (int):
@@ -166,6 +165,7 @@ class Project(models.Model):
         (Status.ACTIVE, 'Active'),
         (Status.ABORTED, 'Aborted'))
 
+    start_datetime = models.DateTimeField(default=timezone.now)
     status = models.IntegerField(choices=STATUS_CHOICES,
                                  default=Status.ACTIVE)
 
@@ -173,7 +173,6 @@ class Project(models.Model):
                                      choices=get_workflow_choices())
 
     short_description = models.TextField()
-    start_datetime = models.DateTimeField(auto_now_add=True)
     priority = models.IntegerField()
     project_data = JSONField(default={})
     task_class = models.IntegerField(


### PR DESCRIPTION
When using `default=timezone.now` in a `DateTimeField`, Django provides a custom time-selector widget in the admin; however, when the model is saved, sub-second resolution is lost, which was causing a parsing error in the project details page. We've decided to leave the time editable in admin at the risk of losing sub-second accuracy in our data, but I've fixed the project details page bug and migrated `start_datetime` for projects to be consistent with the other models.
