### PR TITLE
Optionally require fields in task view

### DIFF
--- a/orchestra/static/orchestra/common/js/orchestra.services.js
+++ b/orchestra/static/orchestra/common/js/orchestra.services.js
@@ -55,10 +55,12 @@ serviceModule.factory('orchestraService', function() {
             registered[signalType].push(callback);
         }
         this.fireSignal = function(signalType) {
+            var success = true;
             registered[signalType] = registered[signalType] || [];
             registered[signalType].forEach(function(callback) {
-                callback();
+                success = callback() && success;
             });
+            return success;
         }
     }
 

--- a/orchestra/static/orchestra/task/css/task.scss
+++ b/orchestra/static/orchestra/task/css/task.scss
@@ -198,4 +198,20 @@ $topbar-height: 5rem;
       }
     }
   }
+
+  .required-field-error {
+    &.checkbox-error {
+      label {
+        border-left: 2px solid red;
+        overflow: auto;
+        margin-bottom: 10px;
+      }
+    }
+    &.text-error {
+      input {
+        border: 1px solid red;
+        box-shadow: 0px 0px 1px red inset;
+      }
+    }
+  }
 }

--- a/orchestra/static/orchestra/task/js/autosave.js
+++ b/orchestra/static/orchestra/task/js/autosave.js
@@ -60,7 +60,12 @@
         autoSaver.saving = true;
         autoSaver.saveError = false;
         autoSaver.cancel();
-        orchestraService.signals.fireSignal('save.before');
+        if (orchestraService.signals.fireSignal('save.before') === false) {
+          // If any of the registered signal handlers returns false, prevent
+          // save.
+          autoSaver.saving = false;
+          return;
+        };
         $http.post('/orchestra/api/interface/save_task_assignment/',
              {'task_id': autoSaver.taskId, 'task_data': autoSaver.data})
         .success(function(data, status, headers, config) {

--- a/orchestra/static/orchestra/task/js/required_fields.js
+++ b/orchestra/static/orchestra/task/js/required_fields.js
@@ -1,0 +1,104 @@
+(function() {
+  'use strict';
+
+  var serviceModule =  angular.module('orchestra.task.services');
+
+  /**
+   * Service to keep track of all required fields in a task view and
+   * validate them on submit.
+   */
+  serviceModule.factory('requiredFields', function($rootScope, orchestraService) {
+    var requiredFields = {
+      fields: [],
+      invalid: [],
+      setup: function(data) {
+        /**
+         * Sets up the base data on which to validate fields.
+         */
+        this.data = data;
+      },
+      require: function(fields) {
+        /**
+         * Sets a field as required. Fields are specified by
+         * dot-delimited key strings (e.g., `key0.key1.key2`).
+         */
+        this.fields = this.fields.concat(fields)
+      },
+      validate: function() {
+        /**
+         * Validates required fields. For the required field
+         * `key0.key1.key2` to be valid, `this.data[key0][key1][key2]`
+         * must exist and not be falsy.
+         */
+        var requiredFields = this;
+        requiredFields.invalid = [];
+        requiredFields.fields.forEach(function(field) {
+          // For each field, check that each successive key exists and
+          // is not falsy.
+          var obj = requiredFields.data;
+          var keys = field.split('.');
+          for (var i in keys) {
+            var key = keys[i];
+            obj = obj[key];
+            if (!obj) {
+              requiredFields.invalid.push(field)
+              break;
+            }
+          }
+        })
+        $rootScope.$broadcast('orchestra:task:validatedFields');
+        return requiredFields.invalid.length === 0;
+      }
+    };
+
+    orchestraService.signals.registerSignal(
+      'submit.before', function() {
+        if (!requiredFields.validate()) {
+          alert('One or more required fields have not been filled out.')
+          return false;
+        };
+      });
+
+    return requiredFields;
+  });
+
+  /**
+   * Provides a directive to wrap required fields in task views.
+   *   - The wrapped HTML should contain an input element bound with
+   *     ngModel.
+   *   - Optionally provide a class to add to the directive wrapper on
+   *     error with `data-error-class="error-class"` on the directive
+   *     element; otherwise, a default is provided for the input type.
+   */
+  angular.module('orchestra.task.directives')
+    .directive('orchestraRequiredField', function($compile, requiredFields) {
+      return {
+        restrict: 'EA',
+        link: function(scope, elem, attrs) {
+          var errorClass = elem.attr('data-error-class');
+          if (!errorClass) {
+            var type = elem.find('input').attr('type');
+            errorClass = type + '-error';
+          }
+          var field = elem.find('input').attr('ng-model');
+          requiredFields.require([field]);
+          var toggleError = function() {
+            if (requiredFields.invalid.indexOf(field) >= 0) {
+              elem.addClass('required-field-error ' + errorClass);
+              scope.$watch(field, function(oldVal, newVal) {
+                if (oldVal != newVal) {
+                  elem.removeClass('required-field-error ' + errorClass);
+                }
+              })
+            }
+            else {
+              elem.removeClass('required-field-error ' + errorClass);
+            }
+          }
+          toggleError();
+          scope.$on('orchestra:task:validatedFields', toggleError);
+        }
+      };
+    });
+
+})()

--- a/orchestra/templates/orchestra/index.html
+++ b/orchestra/templates/orchestra/index.html
@@ -76,6 +76,7 @@
 <script src="{% static "orchestra/task/js/controllers.js" %}" type="text/javascript"></script>
 <script src="{% static "orchestra/task/js/directives.js" %}" type="text/javascript"></script>
 <script src="{% static "orchestra/task/js/autosave.js" %}" type="text/javascript"></script>
+<script src="{% static "orchestra/task/js/required_fields.js" %}" type="text/javascript"></script>
 <script src="{% static "orchestra/dashboard/js/module.js" %}" type="text/javascript"></script>
 <script src="{% static "orchestra/dashboard/js/controllers.js" %}" type="text/javascript"></script>
 <script src="{% static "orchestra/dashboard/js/directives.js" %}" type="text/javascript"></script>


### PR DESCRIPTION
Provides a directive to wrap required fields in task views.
- The wrapped HTML should contain an input element bound with ngModel.
- Optionally provide a class to add to the directive wrapper on error with `data-error-class="error-class"` on the directive element; otherwise, a default is provided for some input types.

<img width="477" alt="screen shot 2015-12-07 at 6 39 46 pm" src="https://cloud.githubusercontent.com/assets/2992765/11643574/cbb931f8-9d12-11e5-92f4-915b077debc8.png">
