### PR TITLE
Make the "End Project" button more informative

### DIFF
--- a/orchestra/static/orchestra/project_management/partials/project_management.html
+++ b/orchestra/static/orchestra/project_management/partials/project_management.html
@@ -17,7 +17,7 @@
             <a href="{{vis.dataService.data.project.admin_url}}" target="_blank">
               <button type="button" class="btn btn-default">View in admin</button>
             </a>
-            <button ng-click="vis.endProject()" class="btn btn-danger">End project</button>
+            <button ng-click="vis.endProject()" class="btn btn-danger">Abort project</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Users who see the old label are tempted to end a project in some clean way.
