### PR TITLE
Ensure certifications for entry_level are migrated before reviewer

### DIFF
--- a/orchestra/workflow/certifications.py
+++ b/orchestra/workflow/certifications.py
@@ -44,7 +44,7 @@ def migrate_certifications(source_workflow_slug,
             continue
 
         for worker_certification in source_worker_certifications.filter(
-                certification=source_certification):
+                certification=source_certification).order_by('role'):
             WorkerCertification.objects.get_or_create(
                 certification=destination_certification,
                 worker=worker_certification.worker,


### PR DESCRIPTION
The command currently doesn't guarantee a migration order, so `reviewer` certifications are sometimes created before their `entry_level` counterparts (raising a `ModelSaveError`).
