### PR TITLE
Add failed status for assignments and retool machine execution logic

### DIFF
--- a/orchestra/machine_tasks.py
+++ b/orchestra/machine_tasks.py
@@ -1,12 +1,20 @@
 from importlib import import_module
 
+import logging
+
+from django.db import transaction
+from django.utils import timezone
+
 from orchestra.core.errors import MachineExecutionError
 from orchestra.models import Project
 from orchestra.models import Task
 from orchestra.models import TaskAssignment
 from orchestra.models import Step
+from orchestra.utils.assignment_snapshots import empty_snapshots
 from orchestra.utils.task_lifecycle import previously_completed_task_data
 from orchestra.utils.task_lifecycle import create_subsequent_tasks
+
+logger = logging.getLogger(__name__)
 
 
 def execute(project_id, step_slug):
@@ -26,31 +34,58 @@ def execute(project_id, step_slug):
     # Machine tasks are only assigned to one worker/machine,
     # so they should only have one task assignment,
     # and should never be submitted for review.
-    count = task.assignments.count()
-    if count > 1:
-        raise MachineExecutionError('At most 1 assignment per machine task')
-    elif count == 1:
-        task_assignment = task.assignments.first()
-        if task_assignment.status == TaskAssignment.Status.SUBMITTED:
-            raise MachineExecutionError('Task assignment completed '
-                                        'but task is not!')
-    else:
-        task_assignment = (
-            TaskAssignment.objects
-            .create(task=task,
-                    status=TaskAssignment.Status.PROCESSING,
-                    in_progress_task_data={},
-                    snapshots={}))
+
+    with transaction.atomic():
+        # Uniqueness constraint on assignnment_counter and task prevents
+        # concurrent creation of more than one assignment
+        task_assignment, created = TaskAssignment.objects.get_or_create(
+            assignment_counter=0,
+            task=task,
+            defaults={
+                'status': TaskAssignment.Status.PROCESSING,
+                'in_progress_task_data': {},
+                'snapshots': empty_snapshots()})
+        if created:
+            task.status = Task.Status.PROCESSING
+            task.save()
+        else:
+            # Task assignment already exists
+            if task_assignment.status == TaskAssignment.Status.FAILED:
+                # Pick up failed task for reprocessing
+                task_assignment.status = TaskAssignment.Status.PROCESSING
+                task_assignment.save()
+            else:
+                # Task assignment already processing
+                raise MachineExecutionError(
+                    'Task already picked up by another machine')
 
     prerequisites = previously_completed_task_data(task)
 
     function_module = import_module(step.execution_function['module'])
     function = getattr(function_module, step.execution_function['name'])
-    task_data = function(project.project_data, prerequisites)
+    try:
+        task_data = function(project.project_data, prerequisites)
+    except:
+        task_assignment.status = TaskAssignment.Status.FAILED
+        logger.exception('Machine task has failed')
+        task_assignment.save()
+        return
     task_assignment.status = TaskAssignment.Status.SUBMITTED
     task_assignment.in_progress_task_data = task_data
     task_assignment.save()
-    task.status = Task.Status.COMPLETE
-    task.save()
-
-    create_subsequent_tasks(project)
+    if task.project.status == Project.Status.ABORTED:
+        # If a long-running task's project was aborted while running, we ensure
+        # the aborted state on the task.
+        task.status = Task.Status.ABORTED
+        task.save()
+    else:
+        task.status = Task.Status.COMPLETE
+        task.save()
+        task_assignment.snapshots['snapshots'].append(
+            {'data': task_assignment.in_progress_task_data,
+             'datetime': timezone.now().isoformat(),
+             'type': TaskAssignment.SnapshotType.SUBMIT,
+             'work_time_seconds': 0
+             })
+        task_assignment.save()
+        create_subsequent_tasks(project)

--- a/orchestra/migrations/0023_assignment_failed.py
+++ b/orchestra/migrations/0023_assignment_failed.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orchestra', '0022_auto_20151217_1642'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='taskassignment',
+            name='status',
+            field=models.IntegerField(choices=[(0, 'Processing'), (1, 'Submitted'), (2, 'Failed')]),
+        ),
+    ]

--- a/orchestra/models.py
+++ b/orchestra/models.py
@@ -407,10 +407,12 @@ class TaskAssignment(models.Model):
     class Status:
         PROCESSING = 0
         SUBMITTED = 1
+        FAILED = 2
 
     STATUS_CHOICES = (
         (Status.PROCESSING, 'Processing'),
-        (Status.SUBMITTED, 'Submitted'))
+        (Status.SUBMITTED, 'Submitted'),
+        (Status.FAILED, 'Failed'))
 
     start_datetime = models.DateTimeField(default=timezone.now)
     worker = models.ForeignKey(Worker,

--- a/orchestra/tests/helpers/workflow.py
+++ b/orchestra/tests/helpers/workflow.py
@@ -9,6 +9,10 @@ def simple_json(project_data, dependencies):
     return {'json': 'simple'}
 
 
+def machine_task_function():
+    pass
+
+
 workflow_fixtures = [
     {
         'slug': 'w1',
@@ -352,6 +356,30 @@ workflow_fixtures = [
                         'description': 'Step B',
                         'is_human': True,
                         'creation_depends_on': ['stepA'],
+                    },
+                ],
+            },
+        ],
+    },
+
+    # The following is a workflow with a single machine step.
+    {
+        'slug': 'machine_workflow',
+        'name': 'Machine workflow',
+        'versions': [
+            {
+                'slug': 'machine_workflow_version',
+                'name': 'v1',
+                'description': 'A workflow with a single machine step',
+                'steps': [
+                    {
+                        'slug': 'machine_step',
+                        'name': 'Machine step',
+                        'description': 'A step to be carried out by a machine',
+                        'is_human': False,
+                        'creation_depends_on': [],
+                        'required_certifications': [],
+                        'execution_function': {},
                     },
                 ],
             },

--- a/orchestra/tests/test_machine_tasks.py
+++ b/orchestra/tests/test_machine_tasks.py
@@ -1,0 +1,127 @@
+from unittest.mock import patch
+
+from orchestra.core.errors import MachineExecutionError
+from orchestra.machine_tasks import execute
+from orchestra.models import Project
+from orchestra.models import Task
+from orchestra.models import TaskAssignment
+from orchestra.tests.helpers import OrchestraTestCase
+from orchestra.tests.helpers.fixtures import setup_models
+from orchestra.tests.helpers.fixtures import ProjectFactory
+from orchestra.utils.task_lifecycle import create_subsequent_tasks
+
+
+class MachineTaskTestCase(OrchestraTestCase):
+    def setUp(self):
+        super(MachineTaskTestCase, self).setUp()
+        setup_models(self)
+
+        machine_workflow_version = (
+            self.workflow_versions['machine_workflow_version'])
+        self.step = machine_workflow_version.steps.get(slug='machine_step')
+        self.assertIsNotNone(self.step)
+        self.step.execution_function = {
+            'module': 'orchestra.tests.helpers.workflow',
+            'name': 'machine_task_function'
+        }
+        self.step.save()
+        patcher = patch(
+            'orchestra.tests.helpers.workflow.machine_task_function',
+            return_value={'data': ''})
+        self.machine_function_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.project = ProjectFactory(
+            workflow_version=machine_workflow_version)
+        create_subsequent_tasks(self.project)
+        self.task = self.project.tasks.first()
+        self.assertIsNotNone(self.task)
+
+        # Since create_subsequent_tasks will automatically run the machine task
+        # we need to reset the task each time it's called
+        self._reset_task()
+
+    def _reset_task(self):
+        self.task.status = Task.Status.AWAITING_PROCESSING
+        self.task.save()
+        self.task.assignments.all().delete()
+        self.machine_function_mock.call_count = 0
+
+    def _assert_correct_machine_task_state(
+            self, assignment_status, task_status):
+        self.task.refresh_from_db()
+        self.assertEquals(
+            self.task.assignments.first().status, assignment_status)
+        self.assertEquals(self.task.status, task_status)
+
+        # Assert that machine function is called once and there is only one
+        # assignment regardless of state
+        self.assertEquals(self.machine_function_mock.call_count, 1)
+        self.assertEquals(self.task.assignments.count(), 1)
+
+    def test_new_task(self):
+        self._reset_task()
+        execute(self.project.id, self.step.slug)
+        self._assert_correct_machine_task_state(
+            TaskAssignment.Status.SUBMITTED, Task.Status.COMPLETE)
+
+    def test_already_processing_task(self):
+        self._reset_task()
+        execute(self.project.id, self.step.slug)
+
+        # Pretend that the task is still processing
+        self.task.status = Task.Status.PROCESSING
+        self.task.save()
+        assignment = self.task.assignments.first()
+        assignment.status = TaskAssignment.Status.PROCESSING
+        assignment.save()
+
+        # Another machine attempts to perform task
+        with self.assertRaises(MachineExecutionError):
+            execute(self.project.id, self.step.slug)
+        self._assert_correct_machine_task_state(
+            TaskAssignment.Status.PROCESSING, Task.Status.PROCESSING)
+
+    def test_already_completed_task(self):
+        self._reset_task()
+        execute(self.project.id, self.step.slug)
+        with self.assertRaises(MachineExecutionError):
+            execute(self.project.id, self.step.slug)
+        self._assert_correct_machine_task_state(
+            TaskAssignment.Status.SUBMITTED, Task.Status.COMPLETE)
+
+    def test_marking_failed_task_assignment(self):
+        self.machine_function_mock.side_effect = Exception('Function failed.')
+        self._reset_task()
+        execute(self.project.id, self.step.slug)
+        self._assert_correct_machine_task_state(
+            TaskAssignment.Status.FAILED, Task.Status.PROCESSING)
+        self.machine_function_mock.side_effect = None
+
+    def test_reassigning_failed_task_assignment(self):
+        self._reset_task()
+        execute(self.project.id, self.step.slug)
+
+        # Pretend that the machine task failed
+        self.task.status = Task.Status.PROCESSING
+        self.task.save()
+        assignment = self.task.assignments.first()
+        assignment.status = TaskAssignment.Status.FAILED
+        assignment.save()
+        self.assertEquals(self.machine_function_mock.call_count, 1)
+        self.machine_function_mock.call_count = 0
+
+        # New machine picks up the failed task
+        execute(self.project.id, self.step.slug)
+        self._assert_correct_machine_task_state(
+            TaskAssignment.Status.SUBMITTED, Task.Status.COMPLETE)
+
+    def test_aborted_project(self):
+        self._reset_task()
+        self.project.status = Project.Status.ABORTED
+        self.project.save()
+        self.task.status = Task.Status.PROCESSING
+        self.task.save()
+        execute(self.project.id, self.step.slug)
+        self._assert_correct_machine_task_state(
+            TaskAssignment.Status.SUBMITTED, Task.Status.ABORTED)


### PR DESCRIPTION
Prevents multiple machines from picking up the same task and handles execution retries correctly.
