### PR TITLE
Simplify task prerequisite data serialization format

### DIFF
--- a/journalism_workflow/static/journalism_workflow/v1/copy_editor/js/controllers.js
+++ b/journalism_workflow/static/journalism_workflow/v1/copy_editor/js/controllers.js
@@ -3,7 +3,7 @@
 
   angular
     .module('journalism_workflow.v1.copy_editor.controllers')
-    .controller('CopyEditorController', CopyEditorController)
+    .controller('CopyEditorController', CopyEditorController);
 
   CopyEditorController.$inject = ['$scope', 'orchestraService'];
 
@@ -11,17 +11,15 @@
     var vm = $scope;
 
     // Store the article text document URL for easier summary later
-    var documentCreationStep = orchestraService.taskUtils.prerequisiteData(
-      vm.taskAssignment, 'document_creation')
-    vm.taskAssignment.task.data.articleDocument = documentCreationStep.task.data.articleURL;
+    var documentCreationStep = vm.taskAssignment.prerequisites.document_creation;
+    vm.taskAssignment.articleDocument = documentCreationStep.articleURL;
 
     // Set up the photos for captioning
-    vm.taskAssignment.task.data.photos = [];
-    var photoAdjustStep = orchestraService.taskUtils.prerequisiteData(
-      vm.taskAssignment, 'photo_adjustment');
-    var photos = photoAdjustStep.task.data.photos_for_caption;
+    vm.taskAssignment.photos = [];
+    var photoAdjustStep = vm.taskAssignment.prerequisites.photo_adjustment;
+    var photos = photoAdjustStep.photos_for_caption;
     for (var i = 0; i < photos.length; i++) {
-      vm.taskAssignment.task.data.photos.push({
+      vm.taskAssignment.photos.push({
         src: photos[i],
         caption: ''
       });

--- a/journalism_workflow/static/journalism_workflow/v1/copy_editor/js/controllers.js
+++ b/journalism_workflow/static/journalism_workflow/v1/copy_editor/js/controllers.js
@@ -15,11 +15,11 @@
     vm.taskAssignment.articleDocument = documentCreationStep.articleURL;
 
     // Set up the photos for captioning
-    vm.taskAssignment.photos = [];
+    vm.taskAssignment.task.data.photos = [];
     var photoAdjustStep = vm.taskAssignment.prerequisites.photo_adjustment;
     var photos = photoAdjustStep.photos_for_caption;
     for (var i = 0; i < photos.length; i++) {
-      vm.taskAssignment.photos.push({
+      vm.taskAssignment.task.data.photos.push({
         src: photos[i],
         caption: ''
       });

--- a/journalism_workflow/static/journalism_workflow/v1/photographer/js/controllers.js
+++ b/journalism_workflow/static/journalism_workflow/v1/photographer/js/controllers.js
@@ -9,12 +9,11 @@
 
   function ImageUploadController($scope, orchestraService) {
     var vm = $scope;
-    var editorStep = orchestraService.taskUtils.prerequisiteData(
-      vm.taskAssignment, 'article_planning');
-    vm.who = editorStep.task.data.who;
-    vm.what = editorStep.task.data.what;
-    vm.when = editorStep.task.data.when;
-    vm.where = editorStep.task.data.where;
-    vm.notes = editorStep.task.data.notes;
+    var editorStep = vm.taskAssignment.prerequisites.article_planning;
+    vm.who = editorStep.who;
+    vm.what = editorStep.what;
+    vm.when = editorStep.when;
+    vm.where = editorStep.where;
+    vm.notes = editorStep.notes;
   }
 })();

--- a/journalism_workflow/static/journalism_workflow/v1/reporter/js/controllers.js
+++ b/journalism_workflow/static/journalism_workflow/v1/reporter/js/controllers.js
@@ -3,22 +3,20 @@
 
   angular
     .module('journalism_workflow.v1.reporter.controllers')
-    .controller('ArticleWritingController', ArticleWritingController)
+    .controller('ArticleWritingController', ArticleWritingController);
 
   ArticleWritingController.$inject = ['$scope', 'orchestraService'];
 
   function ArticleWritingController($scope, orchestraService) {
     var vm = $scope;
-    var editorStep = orchestraService.taskUtils.prerequisiteData(
-      vm.taskAssignment, 'article_planning');
-    vm.who = editorStep.task.data.who;
-    vm.what = editorStep.task.data.what;
-    vm.when = editorStep.task.data.when;
-    vm.where = editorStep.task.data.where;
-    vm.notes = editorStep.task.data.notes;
+    var editorStep = vm.taskAssignment.prerequisites.article_planning;
+    vm.who = editorStep.who;
+    vm.what = editorStep.what;
+    vm.when = editorStep.when;
+    vm.where = editorStep.where;
+    vm.notes = editorStep.notes;
 
-    var documentCreationStep = orchestraService.taskUtils.prerequisiteData(
-      vm.taskAssignment, 'document_creation');
-    vm.articleURL = documentCreationStep.task.data.articleURL;
+    var documentCreationStep = vm.taskAssignment.prerequisites.document_creation;
+    vm.articleURL = documentCreationStep.articleURL;
   }
 })();

--- a/journalism_workflow/v1/adjust_photos.py
+++ b/journalism_workflow/v1/adjust_photos.py
@@ -29,7 +29,6 @@ def autoadjust_photos(project_data, prerequisites):
 
     # List the existing photos
     raw_photo_folder_id = (prerequisites
-                           .get('photography')
                            .get('document_creation')
                            .get('raw_photo_folder'))
     service = Service(settings.GOOGLE_P12_PATH,

--- a/journalism_workflow/v1/adjust_photos.py
+++ b/journalism_workflow/v1/adjust_photos.py
@@ -30,12 +30,7 @@ def autoadjust_photos(project_data, prerequisites):
     # List the existing photos
     raw_photo_folder_id = (prerequisites
                            .get('photography')
-                           .get('prerequisites')
-                           .get('article_planning')
-                           .get('prerequisites')
                            .get('document_creation')
-                           .get('task')
-                           .get('data')
                            .get('raw_photo_folder'))
     service = Service(settings.GOOGLE_P12_PATH,
                       settings.GOOGLE_SERVICE_EMAIL)

--- a/orchestra/static/orchestra/common/js/orchestra.services.js
+++ b/orchestra/static/orchestra/common/js/orchestra.services.js
@@ -26,23 +26,12 @@
       },
     };
     var taskUtils = {
-      prerequisiteData: function(parentStep, desiredStep, dataKey) {
-        var stepsToTraverse = [parentStep];
-        while (stepsToTraverse.length) {
-          var currentStep = stepsToTraverse.pop();
-          if (currentStep.prerequisites.hasOwnProperty(desiredStep)) {
-            var taskData = currentStep.prerequisites[desiredStep].task.data;
-            if (taskData && dataKey) {
-              return taskData[dataKey];
-            }
-            else {
-              return taskData;
-            }
-          }
-          for (var step in currentStep.prerequisites) {
-            stepsToTraverse.push(currentStep.prerequisites[step]);
-          }
+      prerequisiteData: function(taskAssignment, desiredStep, dataKey) {
+        var previousData = taskAssignment.prerequisites[desiredStep];
+        if (dataKey && previousData) {
+          return previousData[dataKey];
         }
+        return previousData;
       },
       updateVersion: function(taskAssignment) {
         if (taskAssignment === undefined ||
@@ -70,9 +59,9 @@
     };
 
     var orchestraService = {
-      'googleUtils': googleUtils,
-      'taskUtils': taskUtils,
-      'signals': signals,
+      googleUtils: googleUtils,
+      taskUtils: taskUtils,
+      signals: signals,
     };
     return orchestraService;
   });

--- a/simple_workflow/static/simple_workflow/v1/rate/js/controllers.js
+++ b/simple_workflow/static/simple_workflow/v1/rate/js/controllers.js
@@ -3,19 +3,18 @@
 
   angular
     .module('simple_workflow.v1.rate.controllers')
-    .controller('ImageRatingController', ImageRatingController)
+    .controller('ImageRatingController', ImageRatingController);
 
   ImageRatingController.$inject = ['$scope', 'orchestraService'];
 
   function ImageRatingController($scope, orchestraService) {
     var vm = $scope;
-    var crawlStep = orchestraService.taskUtils.prerequisiteData(
-      vm.taskAssignment, 'crawl');
-    if (crawlStep.task.data.status !== 'success') {
+    var crawlStep = vm.taskAssignment.prerequisites.crawl;
+    if (crawlStep.status !== 'success') {
       vm.imageURL = "http://media.giphy.com/media/2vA33ikUb0Qz6/giphy.gif";
       vm.success = false;
     } else {
-      vm.imageURL = crawlStep.task.data.image;
+      vm.imageURL = crawlStep.image;
       vm.success = true;
     }
   }


### PR DESCRIPTION
We previously had a nested prerequisite data format (e.g., `vm.taskAssignment.prerequisites.step3.prerequisites.step2.prerequisites.step1...`). This changes the representation to a simple object keyed by step slug, since they're all unique.
