### PR TITLE
Fix a formatting typo in the contributing docs

### DIFF
--- a/docs/source/bots.rst
+++ b/docs/source/bots.rst
@@ -143,6 +143,7 @@ dictionary and can be passed extra ``kwargs`` as shown below::
     return '''A new task is available!
               Find out more about {} at example.com/projects/{}!'''.format(
               kwargs.get('text'), task_details['project']['id'])
+
 Usage
 -----
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -24,11 +24,11 @@ If you've written code that fixes an issue, `create a pull request
 for us to incorporate your changes.
 
 Setting up for Development
-####################
+##########################
 
 We have a `.editorconfig` specified in the top level providing editor defaults
 for our code style. We recommend to install an `EditorConfig
-plugin<http://editorconfig.org/#download>`_ so your editor automatically adheres to our
+plugin <http://editorconfig.org/#download>`_ so your editor automatically adheres to our
 style :).
 
 We recommend using a `virtualenv <https://virtualenv.pypa.io/en/latest/>`_ to


### PR DESCRIPTION
EditorConfig doc link wasn't properly formatted, couldn't be parsed by Sphinx.

(Also fixed a missing newline after a literal block.)
