### PR TITLE
Speedup test suite by using weak hash algo

### DIFF
--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -130,4 +130,9 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = 'staticfiles'
 
+
+TESTING = sys.argv[1:2] == ['test']
+if TESTING:
+    PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+
 setup_orchestra(__name__)


### PR DESCRIPTION
Default password hasher is slow by design, which in turn usually slows down test user creation quite a bit. Relevant doc: https://docs.djangoproject.com/en/1.9/topics/testing/overview/#password-hashing

On my laptop, repeated `time make test` goes from >110s to <60s.
