### PR TITLE
Limit number of parallel processes to 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COVERAGE_ANNOTATION=coverage_annotations
-TEST_CMD=manage.py test orchestra beanstalk_dispatch --with-xunit --parallel --exclude=assert_test*
+TEST_CMD=manage.py test orchestra beanstalk_dispatch --with-xunit --parallel=6 --exclude=assert_test*
 
 clean:
 	find . -name '*.pyo' -delete

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COVERAGE_ANNOTATION=coverage_annotations
-TEST_CMD=manage.py test orchestra beanstalk_dispatch --with-xunit --parallel=6 --exclude=assert_test*
+TEST_CMD=manage.py test orchestra beanstalk_dispatch --with-xunit --parallel=4 --exclude=assert_test*
 
 clean:
 	find . -name '*.pyo' -delete


### PR DESCRIPTION
Before:

```
Ran 191 tests in 78.040s
```

After with 6 processes:

```
Ran 191 tests in 80.788s
```

After with 4 processes:

```
Ran 191 tests in 77.101s
```

Small change, but useful as the number of migrations grows
