### PR TITLE
Increase the number of recently closed tasks while limiting time tracking to only recently closed tasks

### DIFF
--- a/orchestra/static/orchestra/common/js/orchestra.services.js
+++ b/orchestra/static/orchestra/common/js/orchestra.services.js
@@ -110,17 +110,23 @@
         }
         return tasks;
       },
-      tasksForType: function(taskType) {
-        return this.tasks[taskType];
-      },
-      numActiveTasks: function() {
-        var numTasks = 0;
-        for (var taskType in this.tasks) {
-          if (taskType != 'complete') {
-            numTasks += this.tasksForType(taskType).length;
+      activeTasks: function() {
+        var tasks = [];
+        for (var type in this.tasks) {
+          if (type != 'complete') {
+            tasks = tasks.concat(this.tasks[type]);
           }
         }
-        return numTasks;
+        return tasks;
+      },
+      activeAndRecentTasks: function(numRecent) {
+        // Return all active tasks, as well as `numRecent` of the most
+        // recently completed tasks.
+        var tasks = this.activeTasks();
+        return tasks.concat(this.tasks.complete.slice(0, numRecent));
+      },
+      tasksForType: function(taskType) {
+        return this.tasks[taskType];
       },
       getDescription: function(task) {
         if (task) {

--- a/orchestra/static/orchestra/dashboard/partials/dashboard.html
+++ b/orchestra/static/orchestra/dashboard/partials/dashboard.html
@@ -4,7 +4,7 @@
       <div class="row section-header">
         <div class="col-lg-12">
           <h3>
-            Active Tasks ({{ vm.orchestraTasks.numActiveTasks() }})
+            Active Tasks ({{ vm.orchestraTasks.activeTasks().length || 0 }})
             <button type="button"
                     ng-if="vm.enableNewTaskButtons"
                     ng-click="vm.newTask('entry_level')"

--- a/orchestra/static/orchestra/timing/timecard/partials/task-select.html
+++ b/orchestra/static/orchestra/timing/timecard/partials/task-select.html
@@ -3,7 +3,7 @@
   <ui-select-match>
     <span ng-bind="taskSelect.orchestraTasks.getDescription($select.selected)"></span>
   </ui-select-match>
-  <ui-select-choices repeat="item in (taskSelect.orchestraTasks.allTasks() | filter: $select.search) track by item.id">
+  <ui-select-choices repeat="item in (taskSelect.orchestraTasks.activeAndRecentTasks(5) | filter: $select.search) track by item.id">
     <span ng-bind="taskSelect.orchestraTasks.getDescription(item)"></span>
   </ui-select-choices>
 </ui-select>

--- a/orchestra/utils/task_lifecycle.py
+++ b/orchestra/utils/task_lifecycle.py
@@ -461,13 +461,13 @@ def tasks_assigned_to_worker(worker):
             inactive_review_task_assignments.append(task_assignment)
 
     # TODO(marcua): Do a better job of paginating than cutting off to the most
-    # recent 20 tasks.
+    # recent 200 tasks.
     complete_task_assignments = (
         valid_task_assignments
         .filter(worker=worker,
                 task__status=Task.Status.COMPLETE)
         .order_by('-task__project__priority',
-                  '-task__project__start_datetime')[:20])
+                  '-task__project__start_datetime')[:200])
 
     # TODO(jrbotros): convert this to a filterable list
     task_assignments_overview = {


### PR DESCRIPTION
This is a hacky short-term fix in lieu of a more involved overhaul.  It addresses several issues:
- The timesheet report displays tasks that are legitimately assigned to a task assignment as unassigned once the task is no longer in a worker's recently completed tasks.  To bandaid this, I increased the number of recently completed tasks we send to the frontend from 20 to 200.  I tested this on a user with ~100 tasks and saw no serious browser performance degradation on a 2011-era laptop.
- When assigning a new timesheet entry, users were frustrated that all tasks displayed rather than the tasks they are actively working on.  A simple solution would be to only show active tasks, but this would cause an issue if users just closed a project out and then wanted to submit their timesheets.  As a happy medium, this implementation allows users to select from all active tasks and the most recent 5 closed tasks.

A larger overhaul that addresses both of these issues should follow!:)
