### PR TITLE
fix(notifications): handle slack errors silently

### DIFF
--- a/orchestra/communication/slack.py
+++ b/orchestra/communication/slack.py
@@ -34,7 +34,7 @@ def _silent_request(*args, **kwargs):
 BaseAPI._request = _silent_request
 
 
-class OrchestraSlackService(Slacker):
+class OrchestraSlackService(object):
     """
     Wrapper slack service to allow easy swapping and mocking out of API.
     """
@@ -42,7 +42,9 @@ class OrchestraSlackService(Slacker):
     def __init__(self, api_key=None):
         if not api_key:
             api_key = settings.SLACK_EXPERTS_API_KEY
-        super().__init__(api_key)
+        self._service = Slacker(api_key)
+        for attr_name in ('chat', 'groups', 'users'):
+            setattr(self, attr_name, getattr(self._service, attr_name))
 
 
 @run_if('ORCHESTRA_SLACK_EXPERTS_ENABLED')

--- a/orchestra/communication/tests/helpers/slack.py
+++ b/orchestra/communication/tests/helpers/slack.py
@@ -135,7 +135,6 @@ class Groups(BaseAPI):
 
 class Chat(BaseAPI):
     def post_message(self, group_identifier, text, parse='none'):
-        raise Exception('dsgasdg')
         if group_identifier.startswith('#'):
             groups = [
                 group for group in MOCK_SLACK_API_DATA['groups'].values()

--- a/orchestra/communication/tests/helpers/slack.py
+++ b/orchestra/communication/tests/helpers/slack.py
@@ -8,17 +8,20 @@ import slacker
 PREEXISTING_GROUPS = [settings.SLACK_INTERNAL_NOTIFICATION_CHANNEL]
 
 
+MOCK_SLACK_API_DATA = {
+    'groups': {},
+    'users': {},
+    'invited': [],
+}
+
+
 class MockSlacker(MagicMock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.data = {
-            'groups': {},
-            'users': {},
-            'invited': []
-        }
-        self.groups = Groups(self.data)
-        self.chat = Chat(self.data)
-        self.users = Users(self.data)
+        self.data = MOCK_SLACK_API_DATA
+        self.groups = Groups()
+        self.chat = Chat()
+        self.users = Users()
         self.populate_preexisting_groups()
 
     def populate_preexisting_groups(self):
@@ -26,12 +29,12 @@ class MockSlacker(MagicMock):
             self.groups.create(group_name)
 
     def get_messages(self, group_id):
-        return self.data['groups'][group_id]['messages']
+        return MOCK_SLACK_API_DATA['groups'][group_id]['messages']
 
     def clear(self):
-        self.data['groups'].clear()
-        self.data['users'].clear()
-        self.data['invited'][:] = []
+        MOCK_SLACK_API_DATA['groups'].clear()
+        MOCK_SLACK_API_DATA['users'].clear()
+        MOCK_SLACK_API_DATA['invited'][:] = []
         self.populate_preexisting_groups()
 
 
@@ -41,14 +44,11 @@ class BaseAPI(object):
         def __init__(self, body):
             self.body = body
 
-    def __init__(self, data):
-        self.data = data
-
     def _group_exists(self, group_id):
-        return self.data['groups'].get(group_id, None) is not None
+        return MOCK_SLACK_API_DATA['groups'].get(group_id, None) is not None
 
     def _user_exists(self, user_id):
-        return self.data['users'].get(user_id, None) is not None
+        return MOCK_SLACK_API_DATA['users'].get(user_id, None) is not None
 
     def _validate_group(self, group_id):
         if not group_id or not self._group_exists(group_id):
@@ -62,8 +62,8 @@ class BaseAPI(object):
         if command == 'users.admin.invite':
             user_email = data.get('email', None)
             if user_email:
-                if user_email not in self.data['invited']:
-                    self.data['invited'].append(user_email)
+                if user_email not in MOCK_SLACK_API_DATA['invited']:
+                    MOCK_SLACK_API_DATA['invited'].append(user_email)
             else:
                 raise slacker.Error('User email was not provided')
 
@@ -71,10 +71,10 @@ class BaseAPI(object):
         """
         Imitate the user signing up for a slack account after invitation.
         """
-        self.data['invited'].remove(email)
+        MOCK_SLACK_API_DATA['invited'].remove(email)
         # Mock user id is the same as username
         user_id = username
-        self.data['users'][user_id] = {
+        MOCK_SLACK_API_DATA['users'][user_id] = {
             'email': email,
             'name': username
         }
@@ -82,8 +82,8 @@ class BaseAPI(object):
 
 class Groups(BaseAPI):
     def create(self, group_name):
-        group_id = str(len(self.data['groups']))
-        self.data['groups'][group_id] = {
+        group_id = str(len(MOCK_SLACK_API_DATA['groups']))
+        MOCK_SLACK_API_DATA['groups'][group_id] = {
             'id': group_id,
             'users': [],
             'messages': [],
@@ -91,16 +91,18 @@ class Groups(BaseAPI):
             'purpose': None,
             'name': group_name.strip('#'),
         }
-        return self.Response({'group': self.data['groups'][group_id]})
+        return self.Response({
+            'group': MOCK_SLACK_API_DATA['groups'][group_id]
+        })
 
     def invite(self, group_id, user_id):
         self._validate_group(group_id=group_id)
         self._validate_user(user_id=user_id)
 
         already_in_group = True
-        if user_id not in self.data['groups'][group_id]['users']:
+        if user_id not in MOCK_SLACK_API_DATA['groups'][group_id]['users']:
             # Slacker API does not raise an error if user already present
-            self.data['groups'][group_id]['users'].append(user_id)
+            MOCK_SLACK_API_DATA['groups'][group_id]['users'].append(user_id)
             already_in_group = False
         return self.Response({'already_in_group': already_in_group})
 
@@ -108,41 +110,45 @@ class Groups(BaseAPI):
         self._validate_group(group_id=group_id)
         self._validate_user(user_id=user_id)
 
-        if user_id not in self.data['groups'][group_id]['users']:
+        if user_id not in MOCK_SLACK_API_DATA['groups'][group_id]['users']:
             raise slacker.Error('User does not belong to group.')
 
         # Slacker API does not raise an error if user already present
-        self.data['groups'][group_id]['users'].remove(user_id)
+        MOCK_SLACK_API_DATA['groups'][group_id]['users'].remove(user_id)
 
     def set_topic(self, group_id, topic):
         self._validate_group(group_id=group_id)
-        self.data['groups'][group_id]['topic'] = topic
+        MOCK_SLACK_API_DATA['groups'][group_id]['topic'] = topic
 
     def set_purpose(self, group_id, purpose):
         if not self._group_exists(group_id):
             raise slacker.Error('Group not found.')
 
-        self.data['groups'][group_id]['purpose'] = purpose
+        MOCK_SLACK_API_DATA['groups'][group_id]['purpose'] = purpose
 
     def list(self):
-        return self.Response(
-            {'ok': True, 'groups': list(self.data['groups'].values())})
+        return self.Response({
+            'ok': True,
+            'groups': list(MOCK_SLACK_API_DATA['groups'].values())
+        })
 
 
 class Chat(BaseAPI):
     def post_message(self, group_identifier, text, parse='none'):
+        raise Exception('dsgasdg')
         if group_identifier.startswith('#'):
             groups = [
-                group for group in self.data['groups'].values()
+                group for group in MOCK_SLACK_API_DATA['groups'].values()
                 if group['name'] == group_identifier.strip('#')]
             group_identifier = groups[0]['id']
         self._validate_group(group_id=group_identifier)
-        self.data['groups'][group_identifier]['messages'].append(text)
+        MOCK_SLACK_API_DATA[
+            'groups'][group_identifier]['messages'].append(text)
 
 
 class Users(BaseAPI):
     def get_user_id(self, user_name):
-        for uid, uname in self.data['users'].items():
+        for uid, uname in MOCK_SLACK_API_DATA['users'].items():
             if uname == user_name:
                 return uid
         return None

--- a/orchestra/tests/helpers/__init__.py
+++ b/orchestra/tests/helpers/__init__.py
@@ -29,8 +29,10 @@ class OrchestraTestHelpersMixin(object):
         # Without patching the slack API calls, the tests hang indefinitely
         # and you'll need to restart your boot2docker.
         self.slack = MockSlacker()
-        patcher = patch('orchestra.communication.slack.slacker.Slacker',
-                        return_value=self.slack)
+        patcher = patch(
+            'orchestra.communication.slack.Slacker',
+            return_value=self.slack
+        )
         patcher.start()
         self.addCleanup(patcher.stop)
         self.addCleanup(self.slack.clear)

--- a/orchestra/tests/helpers/__init__.py
+++ b/orchestra/tests/helpers/__init__.py
@@ -29,7 +29,7 @@ class OrchestraTestHelpersMixin(object):
         # Without patching the slack API calls, the tests hang indefinitely
         # and you'll need to restart your boot2docker.
         self.slack = MockSlacker()
-        patcher = patch('orchestra.communication.slack.Slacker',
+        patcher = patch('orchestra.communication.slack.slacker.Slacker',
                         return_value=self.slack)
         patcher.start()
         self.addCleanup(patcher.stop)

--- a/orchestra/tests/helpers/__init__.py
+++ b/orchestra/tests/helpers/__init__.py
@@ -30,7 +30,7 @@ class OrchestraTestHelpersMixin(object):
         # and you'll need to restart your boot2docker.
         self.slack = MockSlacker()
         patcher = patch(
-            'orchestra.communication.slack.OrchestraSlackService',
+            'orchestra.communication.slack.Slacker',
             return_value=self.slack
         )
         patcher.start()

--- a/orchestra/tests/helpers/__init__.py
+++ b/orchestra/tests/helpers/__init__.py
@@ -30,7 +30,7 @@ class OrchestraTestHelpersMixin(object):
         # and you'll need to restart your boot2docker.
         self.slack = MockSlacker()
         patcher = patch(
-            'orchestra.communication.slack.Slacker',
+            'orchestra.communication.slack.OrchestraSlackService',
             return_value=self.slack
         )
         patcher.start()

--- a/orchestra/workflow/defaults.py
+++ b/orchestra/workflow/defaults.py
@@ -23,9 +23,9 @@ def get_default_assignment_policy(is_human):
 
 def get_default_creation_policy():
     return {
-            'policy_function': {
-                'path': 'orchestra.creation_policies.always_create',
-            }
+        'policy_function': {
+            'path': 'orchestra.creation_policies.always_create',
+        }
     }
 
 


### PR DESCRIPTION
Right now, Slack exceptions prevent submission of tasks, but we shouldn't be breaking on notifications in most cases.

NOTE: We might not want to ignore slack errors all the time? For example, if we're trying to add someone to a Slack group from the project management view we probably want to surface that error.