### PR TITLE
fixed iframe-wrapper style height error

### DIFF
--- a/orchestra/static/orchestra/common/components/website-iframe/website-iframe.directive.es6.js
+++ b/orchestra/static/orchestra/common/components/website-iframe/website-iframe.directive.es6.js
@@ -32,6 +32,14 @@ export default function websiteIframe ($compile, $sce, $timeout) {
           iframe.setAttribute(attr, iframeAttrs[attr])
         }
 
+        var iframeWrappers = document.getElementsByClassName('iframe-wrapper')
+        for (var i = 0; i < iframeWrappers.length; i++) {
+          if (iframeWrappers[i].children[0].id === 'iframe-wrapper-' + $scope.id) {
+            iframeWrappers[i].style.height = $scope.height || 400
+            break
+          }
+        }
+
         var parent = document.getElementById('iframe-wrapper-' + $scope.id)
         parent.appendChild(iframe)
         $scope.iframe = iframe

--- a/orchestra/static/orchestra/common/components/website-iframe/website-iframe.directive.es6.js
+++ b/orchestra/static/orchestra/common/components/website-iframe/website-iframe.directive.es6.js
@@ -33,7 +33,7 @@ export default function websiteIframe ($compile, $sce, $timeout) {
         }
 
         var iframeWrapper = document.getElementById('iframe-wrapper-' + $scope.id).parentElement
-        iframeWrapper[i].style.height = $scope.height || 400
+        iframeWrapper.style.height = $scope.height || 400
 
         var parent = document.getElementById('iframe-wrapper-' + $scope.id)
         parent.appendChild(iframe)

--- a/orchestra/static/orchestra/common/components/website-iframe/website-iframe.directive.es6.js
+++ b/orchestra/static/orchestra/common/components/website-iframe/website-iframe.directive.es6.js
@@ -32,13 +32,8 @@ export default function websiteIframe ($compile, $sce, $timeout) {
           iframe.setAttribute(attr, iframeAttrs[attr])
         }
 
-        var iframeWrappers = document.getElementsByClassName('iframe-wrapper')
-        for (var i = 0; i < iframeWrappers.length; i++) {
-          if (iframeWrappers[i].children[0].id === 'iframe-wrapper-' + $scope.id) {
-            iframeWrappers[i].style.height = $scope.height || 400
-            break
-          }
-        }
+        var iframeWrapper = document.getElementById('iframe-wrapper-' + $scope.id).parentElement
+        iframeWrapper[i].style.height = $scope.height || 400
 
         var parent = document.getElementById('iframe-wrapper-' + $scope.id)
         parent.appendChild(iframe)


### PR DESCRIPTION
The `iframe-wrapper` parent div of the iframe does not appropriately update its height when a height is passed into `website-iframe`. This leads to a UI bug where the iframe overflows out of its box in the UI.

This is a fix for that.