### PR TITLE
Add project management/admin capabilities to team card

### DIFF
--- a/orchestra/interface_api/project_management/tests/test_project_management_api.py
+++ b/orchestra/interface_api/project_management/tests/test_project_management_api.py
@@ -253,10 +253,6 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
         self.assertEqual(response.status_code, 200)
         task.refresh_from_db()
         self.assertEqual(task.status, Task.Status.COMPLETE)
-        # Check that dependent tasks have already been created
-        num_tasks = task.project.tasks.count()
-        create_subsequent_tasks(task.project)
-        self.assertEqual(task.project.tasks.count(), num_tasks)
 
     def test_end_project_api(self):
         project = self.projects['project_to_end']

--- a/orchestra/interface_api/project_management/tests/test_project_management_api.py
+++ b/orchestra/interface_api/project_management/tests/test_project_management_api.py
@@ -233,7 +233,7 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
             self.assertEqual(
                 assignment.status, assignment_statuses[index])
 
-        task = self.tasks['no_task_assignments']
+        task = self.tasks['awaiting_processing']
         response = self.api_client.post(
             reverse(
                 'orchestra:orchestra:project_management:'

--- a/orchestra/interface_api/project_management/tests/test_project_management_api.py
+++ b/orchestra/interface_api/project_management/tests/test_project_management_api.py
@@ -254,28 +254,6 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
         task.refresh_from_db()
         self.assertEqual(task.status, Task.Status.COMPLETE)
 
-        # This task, when submitted, will be marked as completed because
-        # it has been reviewed enough times.
-        task = self.tasks['review_nearly_complete_task']
-        response = self.api_client.post(
-            reverse(
-                'orchestra:orchestra:project_management:'
-                'complete_and_skip_task'),
-            json.dumps({
-                'task_id': task.id,
-            }),
-            content_type='application/json')
-        self.assertEqual(response.status_code, 200)
-        task.refresh_from_db()
-        self.assertEqual(task.status, Task.Status.COMPLETE)
-        assignment_statuses = [
-            TaskAssignment.Status.SUBMITTED, TaskAssignment.Status.SUBMITTED,
-            TaskAssignment.Status.SUBMITTED]
-        for index, assignment in enumerate(
-                task.assignments.all().order_by('assignment_counter')):
-            self.assertEqual(
-                assignment.status, assignment_statuses[index])
-
     def test_end_project_api(self):
         project = self.projects['project_to_end']
         response = self.api_client.post(

--- a/orchestra/interface_api/project_management/tests/test_project_management_api.py
+++ b/orchestra/interface_api/project_management/tests/test_project_management_api.py
@@ -244,7 +244,7 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
             content_type='application/json')
         self.assertEqual(response.status_code, 200)
         task.refresh_from_db()
-        self.assertEqual(task.status, Task.Status.COMPLETED)
+        self.assertEqual(task.status, Task.Status.COMPLETE)
 
         task = self.tasks['next_todo_task']
         response = self.api_client.post(
@@ -257,7 +257,7 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
             content_type='application/json')
         self.assertEqual(response.status_code, 200)
         task.refresh_from_db()
-        self.assertEqual(task.status, Task.Status.COMPLETED)
+        self.assertEqual(task.status, Task.Status.COMPLETE)
         for assignment in task.assignments.all():
             self.assertEqual(
                 assignment.status, TaskAssignment.Status.SUBMITTED)

--- a/orchestra/interface_api/project_management/tests/test_project_management_api.py
+++ b/orchestra/interface_api/project_management/tests/test_project_management_api.py
@@ -254,6 +254,28 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
         task.refresh_from_db()
         self.assertEqual(task.status, Task.Status.COMPLETE)
 
+        # This task, when submitted, will be marked as completed because
+        # it has been reviewed enough times.
+        task = self.tasks['review_nearly_complete_task']
+        response = self.api_client.post(
+            reverse(
+                'orchestra:orchestra:project_management:'
+                'complete_and_skip_task'),
+            json.dumps({
+                'task_id': task.id,
+            }),
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        task.refresh_from_db()
+        self.assertEqual(task.status, Task.Status.COMPLETE)
+        assignment_statuses = [
+            TaskAssignment.Status.SUBMITTED, TaskAssignment.Status.SUBMITTED,
+            TaskAssignment.Status.SUBMITTED]
+        for index, assignment in enumerate(
+                task.assignments.all().order_by('assignment_counter')):
+            self.assertEqual(
+                assignment.status, assignment_statuses[index])
+
     def test_end_project_api(self):
         project = self.projects['project_to_end']
         response = self.api_client.post(

--- a/orchestra/interface_api/project_management/views.py
+++ b/orchestra/interface_api/project_management/views.py
@@ -17,7 +17,7 @@ from orchestra.interface_api.project_management.decorators import \
 from orchestra.models import Project
 from orchestra.models import Task
 from orchestra.models import Worker
-from orchestra.project_api.serializers import ProjectSerializer
+from orchestra.project_api.serializers import ProjectSummarySerializer
 from orchestra.utils.load_json import load_encoded_json
 from orchestra.utils.revert import revert_task_to_iteration
 from orchestra.utils.task_lifecycle import assign_task
@@ -34,7 +34,7 @@ class IsProjectAdmin(permissions.BasePermission):
 
 class ProjectList(generics.ListCreateAPIView):
     permission_classes = (permissions.IsAuthenticated, IsProjectAdmin)
-    serializer_class = ProjectSerializer
+    serializer_class = ProjectSummarySerializer
     queryset = Project.objects.exclude(status=Project.Status.ABORTED)
 
 

--- a/orchestra/project_api/serializers.py
+++ b/orchestra/project_api/serializers.py
@@ -47,6 +47,17 @@ class ProjectSerializer(serializers.ModelSerializer):
         return obj.project_data
 
 
+class ProjectSummarySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Project
+        fields = (
+            'id',
+            'short_description',
+            'start_datetime',
+        )
+
+
 class TaskSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/orchestra/static/dist/main.css
+++ b/orchestra/static/dist/main.css
@@ -37,6 +37,12 @@
   padding-left: 0;
   padding-right: 0; }
 
+@keyframes spin {
+  from {
+    transform: rotate(0deg); }
+  to {
+    transform: rotate(360deg); } }
+
 .checklist-wrapper {
   width: 100%;
   padding: 15px; }
@@ -1366,6 +1372,12 @@ li.checklist-item, .new-item {
   padding-left: 0;
   padding-right: 0; }
 
+@keyframes spin {
+  from {
+    transform: rotate(0deg); }
+  to {
+    transform: rotate(360deg); } }
+
 .website-iframe {
   width: 100%;
   border: 1px solid #cccccc; }
@@ -1386,6 +1398,12 @@ li.checklist-item, .new-item {
 .row.no-padding, .row.no-padding > [class*="col-"] {
   padding-left: 0;
   padding-right: 0; }
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg); }
+  to {
+    transform: rotate(360deg); } }
 
 /**
  * Base stylesheet for Orchestra.
@@ -1522,7 +1540,7 @@ a.logo {
   padding-left: 0;
   padding-right: 0; }
 
-.project-management .vis-wrapper .overlay .spinner::after {
+.project-management .overlay .spinner::after {
   position: absolute;
   top: 0;
   left: 0;
@@ -1533,6 +1551,12 @@ a.logo {
   border-radius: 50%;
   content: "";
   animation: spin .75s linear infinite; }
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg); }
+  to {
+    transform: rotate(360deg); } }
 
 .project-management-modal, .slack-modal, .data-modal, .revert-modal {
   font-size: 1.5rem;
@@ -1566,6 +1590,22 @@ a.logo {
   margin-top: 75px;
   font-size: 1.5rem;
   position: relative; }
+  .project-management .overlay {
+    position: absolute;
+    top: 0;
+    left: 20px;
+    right: 20px;
+    bottom: 0;
+    background-color: white;
+    opacity: 0.75;
+    z-index: 100; }
+    .project-management .overlay .spinner {
+      position: absolute;
+      width: 40px;
+      height: 40px;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%); }
   .project-management .project-description.ui-select-bootstrap {
     margin: 10px 0; }
     .project-management .project-description.ui-select-bootstrap > .ui-select-match > .btn {
@@ -1608,22 +1648,6 @@ a.logo {
     position: relative;
     margin-bottom: 75px;
     min-height: 200px; }
-    .project-management .vis-wrapper .overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background-color: white;
-      opacity: 0.75;
-      z-index: 100; }
-      .project-management .vis-wrapper .overlay .spinner {
-        position: absolute;
-        width: 40px;
-        height: 40px;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%); }
     .project-management .vis-wrapper .svg-wrapper {
       overflow-x: auto;
       overflow-y: hidden;
@@ -1672,6 +1696,12 @@ a.logo {
 .row.no-padding, .row.no-padding > [class*="col-"] {
   padding-left: 0;
   padding-right: 0; }
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg); }
+  to {
+    transform: rotate(360deg); } }
 
 /* Confirmation modals */
 .modal-confirm-submit {
@@ -1984,19 +2014,15 @@ a.logo {
     border-radius: 3px; }
   .is-disabled .pika-button,
   .is-outside-current-month .pika-button {
+    pointer-events: none;
+    cursor: default;
     color: #999;
     opacity: .3; }
-  .is-disabled .pika-button {
-    pointer-events: none;
-    cursor: default; }
   .pika-button:hover {
     color: #fff;
     background: #ff8000;
     box-shadow: none;
     border-radius: 3px; }
-  .pika-button .is-selection-disabled {
-    pointer-events: none;
-    cursor: default; }
 
 .pika-week {
   font-size: 11px;
@@ -2033,6 +2059,12 @@ a.logo {
 .row.no-padding, .row.no-padding > [class*="col-"] {
   padding-left: 0;
   padding-right: 0; }
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg); }
+  to {
+    transform: rotate(360deg); } }
 
 .timecard-view {
   position: absolute;
@@ -2163,6 +2195,12 @@ a.logo {
 .row.no-padding, .row.no-padding > [class*="col-"] {
   padding-left: 0;
   padding-right: 0; }
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg); }
+  to {
+    transform: rotate(360deg); } }
 
 .timer {
   font-size: 18px; }

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -61648,13 +61648,16 @@ function teamInfoCard(orchestraApi) {
     template: _teamInfoCard2.default,
     restrict: 'E',
     scope: {
-      projectId: '=',
-      isProjectAdmin: '='
+      taskAssignment: '='
     },
     controllerAs: 'teamInfoCard',
     bindToController: true,
     controller: function controller($scope) {
       var teamInfoCard = $scope.teamInfoCard;
+      teamInfoCard.projectId = teamInfoCard.taskAssignment.project.id;
+      teamInfoCard.step = teamInfoCard.taskAssignment.step;
+      teamInfoCard.isProjectAdmin = teamInfoCard.taskAssignment.is_project_admin;
+
       teamInfoCard.loadTeamInfo = function () {
         orchestraApi.projectInformation(teamInfoCard.projectId).then(function (response) {
           var _response$data = response.data,
@@ -61683,6 +61686,7 @@ function teamInfoCard(orchestraApi) {
               if (task) {
                 teamInfoCard.assignments = teamInfoCard.assignments.concat(task.assignments.map(function (a) {
                   return {
+                    stepSlug: stepSlug,
                     role: teamInfoCard.steps[stepSlug].name,
                     worker: a.worker,
                     recordedTime: _momentTimezone2.default.duration(a.recorded_work_time, 'seconds').roundMinute().humanizeUnits(),
@@ -61733,7 +61737,7 @@ function teamInfoCard(orchestraApi) {
 /* 217 */
 /***/ (function(module, exports) {
 
-module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          Team info\n          <a class=\"btn\"\n             ng-if=\"teamInfoCard.isProjectAdmin\"\n             ng-href=\"project/{{teamInfoCard.projectId}}\"\n             target=\"_blank\">\n            Project Management\n          </a>\n        </h3>\n      </div>\n    </div>\n    <div class=\"row section-body\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <table class=\"table table-striped\">\n          <thead>\n            <th>Role</th>\n            <th>Username</th>\n            <th>Name</th>\n            <th>Recorded time spent</th>\n            <th>Status</th>\n          </thead>\n          <tbody>\n            <tr ng-repeat=\"assignment in teamInfoCard.assignments\">\n              <td>{{assignment.role}}</td>\n              <td>{{assignment.worker.username}}</td>\n              <td>{{assignment.worker.first_name}} {{assignment.worker.last_name}}</td>\n              <td>{{assignment.recordedTime}}</td>\n              <td>\n                {{assignment.status}}\n                <button type=\"submit\"\n                        class=\"btn btn-secondary btn-sm\"\n                        ng-if=\"teamInfoCard.isProjectAdmin &&\n                               assignment.status == 'Processing'\"\n                        ng-click=\"teamInfoCard.submitTask(assignment.task_id)\">\n                  Submit\n                </button>\n              </td>\n            </tr>\n          </tbody>\n        </table>\n      </div>\n    </div>\n  </div>\n</section>\n";
+module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          Team info\n          <a class=\"btn\"\n             ng-if=\"teamInfoCard.isProjectAdmin\"\n             ng-href=\"project/{{teamInfoCard.projectId}}\"\n             target=\"_blank\">\n            Project Management\n          </a>\n        </h3>\n      </div>\n    </div>\n    <div class=\"row section-body\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <table class=\"table table-striped\">\n          <thead>\n            <th>Role</th>\n            <th>Username</th>\n            <th>Name</th>\n            <th>Recorded time spent</th>\n            <th>Status</th>\n          </thead>\n          <tbody>\n            <tr ng-repeat=\"assignment in teamInfoCard.assignments\">\n              <td>{{assignment.role}}</td>\n              <td>{{assignment.worker.username}}</td>\n              <td>{{assignment.worker.first_name}} {{assignment.worker.last_name}}</td>\n              <td>{{assignment.recordedTime}}</td>\n              <td>\n                {{assignment.status}}\n                <button type=\"submit\"\n                        class=\"btn btn-default btn-sm\"\n                        ng-if=\"teamInfoCard.isProjectAdmin &&\n                               assignment.status == 'Processing' &&\n                               assignment.stepSlug != teamInfoCard.step.slug\"\n                        ng-click=\"teamInfoCard.submitTask(assignment.task_id)\">\n                  Submit\n                </button>\n              </td>\n            </tr>\n          </tbody>\n        </table>\n      </div>\n    </div>\n  </div>\n</section>\n";
 
 /***/ }),
 /* 218 */

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -55715,10 +55715,10 @@ function tasktable() {
     },
     controllerAs: 'vm',
     bindToController: true,
-    controller: function controller($location, $timeout, orchestraTasks) {
+    controller: function controller($location, $timeout, $window, orchestraTasks) {
       var vm = this;
       vm.openTask = function (task) {
-        $location.path('task/' + task.id);
+        $window.open('task/' + task.id, '_blank');
       };
       // Surface service to interpolator
       vm.orchestraTasks = orchestraTasks;
@@ -57693,10 +57693,12 @@ function dataService($location, $rootScope, $route, orchestraApi) {
     },
     getAllProjects: function getAllProjects() {
       var dataService = this;
+      dataService.loading = true;
       dataService.ready = orchestraApi.allProjects().then(function (response) {
         response.data.forEach(function (project) {
           dataService.allProjects[project.id] = project;
         });
+        dataService.loading = false;
       });
       return dataService.ready;
     },
@@ -59256,6 +59258,22 @@ function datePicker(timeEntries) {
         }
     },
 
+    fireEvent = function(el, eventName, data)
+    {
+        var ev;
+
+        if (document.createEvent) {
+            ev = document.createEvent('HTMLEvents');
+            ev.initEvent(eventName, true, false);
+            ev = extend(ev, data);
+            el.dispatchEvent(ev);
+        } else if (document.createEventObject) {
+            ev = document.createEventObject();
+            ev = extend(ev, data);
+            el.fireEvent('on' + eventName, ev);
+        }
+    },
+
     trim = function(str)
     {
         return str.trim ? str.trim() : str.replace(/^\s+|\s+$/g,'');
@@ -59341,22 +59359,6 @@ function datePicker(timeEntries) {
         return to;
     },
 
-    fireEvent = function(el, eventName, data)
-    {
-        var ev;
-
-        if (document.createEvent) {
-            ev = document.createEvent('HTMLEvents');
-            ev.initEvent(eventName, true, false);
-            ev = extend(ev, data);
-            el.dispatchEvent(ev);
-        } else if (document.createEventObject) {
-            ev = document.createEventObject();
-            ev = extend(ev, data);
-            el.fireEvent('on' + eventName, ev);
-        }
-    },
-
     adjustCalendar = function(calendar) {
         if (calendar.month < 0) {
             calendar.year -= Math.ceil(Math.abs(calendar.month)/12);
@@ -59390,13 +59392,6 @@ function datePicker(timeEntries) {
         // the default output format for `.toString()` and `field` value
         format: 'YYYY-MM-DD',
 
-        // the toString function which gets passed a current date object and format
-        // and returns a string
-        toString: null,
-
-        // used to create date object from current input string
-        parse: null,
-
         // the initial date to view when first opened
         defaultDate: null,
 
@@ -59420,9 +59415,6 @@ function datePicker(timeEntries) {
         // show week numbers at head of row
         showWeekNumber: false,
 
-        // Week picker mode
-        pickWholeWeek: false,
-
         // used internally (don't config outside)
         minYear: 0,
         maxYear: 9999,
@@ -59443,9 +59435,6 @@ function datePicker(timeEntries) {
         // Render days of the calendar grid that fall in the next or previous month
         showDaysInNextAndPreviousMonths: false,
 
-        // Allows user to select days that fall in the next or previous month
-        enableSelectionDaysInNextAndPreviousMonths: false,
-
         // how many months are visible
         numberOfMonths: 1,
 
@@ -59455,9 +59444,6 @@ function datePicker(timeEntries) {
 
         // Specify a DOM element to render the calendar in
         container: undefined,
-
-        // Blur field when date is selected
-        blurFieldOnSelect : true,
 
         // internationalization
         i18n: {
@@ -59471,17 +59457,11 @@ function datePicker(timeEntries) {
         // Theme Classname
         theme: null,
 
-        // events array
-        events: [],
-
         // callback function
         onSelect: null,
         onOpen: null,
         onClose: null,
-        onDraw: null,
-
-        // Enable keyboard input
-        keyboardInput: true
+        onDraw: null
     },
 
 
@@ -59504,11 +59484,6 @@ function datePicker(timeEntries) {
         if (opts.isEmpty) {
             if (opts.showDaysInNextAndPreviousMonths) {
                 arr.push('is-outside-current-month');
-
-                if(!opts.enableSelectionDaysInNextAndPreviousMonths) {
-                    arr.push('is-selection-disabled');
-                }
-
             } else {
                 return '<td class="is-empty"></td>';
             }
@@ -59522,9 +59497,6 @@ function datePicker(timeEntries) {
         if (opts.isSelected) {
             arr.push('is-selected');
             ariaSelected = 'true';
-        }
-        if (opts.hasEvent) {
-            arr.push('has-event');
         }
         if (opts.isInRange) {
             arr.push('is-inrange');
@@ -59550,9 +59522,9 @@ function datePicker(timeEntries) {
         return '<td class="pika-week">' + weekNum + '</td>';
     },
 
-    renderRow = function(days, isRTL, pickWholeWeek, isRowSelected)
+    renderRow = function(days, isRTL)
     {
-        return '<tr class="pika-row' + (pickWholeWeek ? ' pick-whole-week' : '') + (isRowSelected ? ' is-selected' : '') + '">' + (isRTL ? days.reverse() : days).join('') + '</tr>';
+        return '<tr>' + (isRTL ? days.reverse() : days).join('') + '</tr>';
     },
 
     renderBody = function(rows)
@@ -59663,7 +59635,7 @@ function datePicker(timeEntries) {
                     if (opts.bound) {
                         sto(function() {
                             self.hide();
-                            if (opts.blurFieldOnSelect && opts.field) {
+                            if (opts.field) {
                                 opts.field.blur();
                             }
                         }, 100);
@@ -59713,9 +59685,7 @@ function datePicker(timeEntries) {
                 switch(e.keyCode){
                     case 13:
                     case 27:
-                        if (opts.field) {
-                            opts.field.blur();
-                        }
+                        opts.field.blur();
                         break;
                     case 37:
                         e.preventDefault();
@@ -59741,9 +59711,7 @@ function datePicker(timeEntries) {
             if (e.firedBy === self) {
                 return;
             }
-            if (opts.parse) {
-                date = opts.parse(opts.field.value, opts.format);
-            } else if (hasMoment) {
+            if (hasMoment) {
                 date = moment(opts.field.value, opts.format, opts.formatStrict);
                 date = (date && date.isValid()) ? date.toDate() : null;
             }
@@ -59818,10 +59786,7 @@ function datePicker(timeEntries) {
         addEvent(self.el, 'mousedown', self._onMouseDown, true);
         addEvent(self.el, 'touchend', self._onMouseDown, true);
         addEvent(self.el, 'change', self._onChange);
-
-        if (opts.keyboardInput) {
-            addEvent(document, 'keydown', self._onKeyChange);
-        }
+        addEvent(document, 'keydown', self._onKeyChange);
 
         if (opts.field) {
             if (opts.container) {
@@ -59936,17 +59901,7 @@ function datePicker(timeEntries) {
          */
         toString: function(format)
         {
-            format = format || this._o.format;
-            if (!isDate(this._d)) {
-                return '';
-            }
-            if (this._o.toString) {
-              return this._o.toString(this._d, format);
-            }
-            if (hasMoment) {
-              return moment(this._d).format(format);
-            }
-            return this._d.toDateString();
+            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || this._o.format) : this._d.toDateString();
         },
 
         /**
@@ -59968,11 +59923,11 @@ function datePicker(timeEntries) {
         },
 
         /**
-         * return a Date object of the current selection
+         * return a Date object of the current selection with fallback for the current date
          */
         getDate: function()
         {
-            return isDate(this._d) ? new Date(this._d.getTime()) : null;
+            return isDate(this._d) ? new Date(this._d.getTime()) : new Date();
         },
 
         /**
@@ -60055,7 +60010,7 @@ function datePicker(timeEntries) {
 
         adjustDate: function(sign, days) {
 
-            var day = this.getDate() || new Date();
+            var day = this.getDate();
             var difference = parseInt(days)*24*60*60*1000;
 
             var newDay;
@@ -60064,6 +60019,14 @@ function datePicker(timeEntries) {
                 newDay = new Date(day.valueOf() + difference);
             } else if (sign === 'subtract') {
                 newDay = new Date(day.valueOf() - difference);
+            }
+
+            if (hasMoment) {
+                if (sign === 'add') {
+                    newDay = moment(day).add(days, "days").toDate();
+                } else if (sign === 'subtract') {
+                    newDay = moment(day).subtract(days, "days").toDate();
+                }
             }
 
             this.setDate(newDay);
@@ -60217,7 +60180,7 @@ function datePicker(timeEntries) {
             if (typeof this._o.onDraw === 'function') {
                 this._o.onDraw(this);
             }
-
+            
             if (opts.bound) {
                 // let the screen reader user know to use arrow keys
                 opts.field.setAttribute('aria-label', 'Use the arrow keys to pick a date');
@@ -60304,13 +60267,11 @@ function datePicker(timeEntries) {
                 after -= 7;
             }
             cells += 7 - after;
-            var isWeekSelected = false;
             for (var i = 0, r = 0; i < cells; i++)
             {
                 var day = new Date(year, month, 1 + (i - before)),
                     isSelected = isDate(this._d) ? compareDates(day, this._d) : false,
                     isToday = compareDates(day, now),
-                    hasEvent = opts.events.indexOf(day.toDateString()) !== -1 ? true : false,
                     isEmpty = i < before || i >= (days + before),
                     dayNumber = 1 + (i - before),
                     monthNumber = month,
@@ -60339,7 +60300,6 @@ function datePicker(timeEntries) {
                         day: dayNumber,
                         month: monthNumber,
                         year: yearNumber,
-                        hasEvent: hasEvent,
                         isSelected: isSelected,
                         isToday: isToday,
                         isDisabled: isDisabled,
@@ -60347,13 +60307,8 @@ function datePicker(timeEntries) {
                         isStartRange: isStartRange,
                         isEndRange: isEndRange,
                         isInRange: isInRange,
-                        showDaysInNextAndPreviousMonths: opts.showDaysInNextAndPreviousMonths,
-                        enableSelectionDaysInNextAndPreviousMonths: opts.enableSelectionDaysInNextAndPreviousMonths
+                        showDaysInNextAndPreviousMonths: opts.showDaysInNextAndPreviousMonths
                     };
-
-                if (opts.pickWholeWeek && isSelected) {
-                    isWeekSelected = true;
-                }
 
                 row.push(renderDay(dayConfig));
 
@@ -60361,10 +60316,9 @@ function datePicker(timeEntries) {
                     if (opts.showWeekNumber) {
                         row.unshift(renderWeek(i - before, month, year));
                     }
-                    data.push(renderRow(row, opts.isRTL, opts.pickWholeWeek, isWeekSelected));
+                    data.push(renderRow(row, opts.isRTL));
                     row = [];
                     r = 0;
-                    isWeekSelected = false;
                 }
             }
             return renderTable(opts, data, randId);
@@ -60378,9 +60332,9 @@ function datePicker(timeEntries) {
         show: function()
         {
             if (!this.isVisible()) {
+                removeClass(this.el, 'is-hidden');
                 this._v = true;
                 this.draw();
-                removeClass(this.el, 'is-hidden');
                 if (this._o.bound) {
                     addEvent(document, 'click', this._onClick);
                     this.adjustPosition();
@@ -60414,21 +60368,16 @@ function datePicker(timeEntries) {
          */
         destroy: function()
         {
-            var opts = this._o;
-
             this.hide();
             removeEvent(this.el, 'mousedown', this._onMouseDown, true);
             removeEvent(this.el, 'touchend', this._onMouseDown, true);
             removeEvent(this.el, 'change', this._onChange);
-            if (opts.keyboardInput) {
-                removeEvent(document, 'keydown', this._onKeyChange);
-            }
-            if (opts.field) {
-                removeEvent(opts.field, 'change', this._onInputChange);
-                if (opts.bound) {
-                    removeEvent(opts.trigger, 'click', this._onInputClick);
-                    removeEvent(opts.trigger, 'focus', this._onInputFocus);
-                    removeEvent(opts.trigger, 'blur', this._onInputBlur);
+            if (this._o.field) {
+                removeEvent(this._o.field, 'change', this._onInputChange);
+                if (this._o.bound) {
+                    removeEvent(this._o.trigger, 'click', this._onInputClick);
+                    removeEvent(this._o.trigger, 'focus', this._onInputFocus);
+                    removeEvent(this._o.trigger, 'blur', this._onInputBlur);
                 }
             }
             if (this.el.parentNode) {
@@ -60439,6 +60388,7 @@ function datePicker(timeEntries) {
     };
 
     return Pikaday;
+
 }));
 
 
@@ -61698,7 +61648,8 @@ function teamInfoCard(orchestraApi) {
     template: _teamInfoCard2.default,
     restrict: 'E',
     scope: {
-      projectId: '='
+      projectId: '=',
+      isProjectAdmin: '='
     },
     controllerAs: 'teamInfoCard',
     bindToController: true,
@@ -61733,7 +61684,9 @@ function teamInfoCard(orchestraApi) {
                 return {
                   role: teamInfoCard.steps[stepSlug].name,
                   worker: a.worker,
-                  recordedTime: _momentTimezone2.default.duration(a.recorded_work_time, 'seconds').roundMinute().humanizeUnits()
+                  recordedTime: _momentTimezone2.default.duration(a.recorded_work_time, 'seconds').roundMinute().humanizeUnits(),
+                  status: task.status,
+                  task_id: a.task
                 };
               }));
             }
@@ -61765,7 +61718,7 @@ function teamInfoCard(orchestraApi) {
 /* 217 */
 /***/ (function(module, exports) {
 
-module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          Team info\n        </h3>\n      </div>\n    </div>\n    <div class=\"row section-body\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <table class=\"table table-striped\">\n          <thead>\n            <th>Role</th>\n            <th>Username</th>\n            <th>Name</th>\n            <th>Recorded time spent</th>\n          </thead>\n          <tbody>\n            <tr ng-repeat=\"assignment in teamInfoCard.assignments\">\n              <td>{{assignment.role}}</td>\n              <td>{{assignment.worker.username}}</td>\n              <td>{{assignment.worker.first_name}} {{assignment.worker.last_name}}</td>\n              <td>{{assignment.recordedTime}}</td>\n            </tr>\n          </tbody>\n        </table>\n      </div>\n    </div>\n  </div>\n</section>\n";
+module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          Team info\n          <a class=\"btn\"\n             ng-if=\"teamInfoCard.isProjectAdmin\"\n             ng-href=\"project/{{teamInfoCard.projectId}}\"\n             target=\"_blank\">\n            Project Management\n          </a>\n        </h3>\n      </div>\n    </div>\n    <div class=\"row section-body\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <table class=\"table table-striped\">\n          <thead>\n            <th>Role</th>\n            <th>Username</th>\n            <th>Name</th>\n            <th>Recorded time spent</th>\n            <th>Status</th>\n          </thead>\n          <tbody>\n            <tr ng-repeat=\"assignment in teamInfoCard.assignments\">\n              <td>{{assignment.role}}</td>\n              <td>{{assignment.worker.username}}</td>\n              <td>{{assignment.worker.first_name}} {{assignment.worker.last_name}}</td>\n              <td>{{assignment.recordedTime}}</td>\n              <td>\n                {{assignment.status}}\n                <button type=\"submit\"\n                        class=\"btn btn-secondary btn-sm\"\n                        ng-if=\"teamInfoCard.isProjectAdmin &&\n                               assignment.status == 'Processing'\"\n                        ng-click=\"teamInfoCard.something()\">\n                  Submit\n                </button>\n              </td>\n            </tr>\n          </tbody>\n        </table>\n      </div>\n    </div>\n  </div>\n</section>\n";
 
 /***/ }),
 /* 218 */
@@ -61850,7 +61803,7 @@ module.exports = "<div class=\"timecard-view\" ng-if=\"!vm.dataLoading\">\n  <di
 /* 222 */
 /***/ (function(module, exports) {
 
-module.exports = "<div class=\"project-management\">\n  <section class=\"section-panel\">\n    <div class=\"container-fluid\">\n      <div class=\"row padded\">\n        <div class=\"col-lg-12 col-md-12 col-sm-12\">\n          <ui-select class=\"project-description\" ng-model=\"vis.dataService.currentProject\"\n              ng-change=\"vis.dataService.setSelectedProject()\"\n              ng-disabled=\"vis.dataService.loading\">\n            <ui-select-match>\n              <span ng-bind=\"projectDescription($select.selected)\"></span>\n            </ui-select-match>\n            <ui-select-choices repeat=\"item in (vis.dataService.allProjects | toArray | filter: $select.search) track by item.id\">\n              <span ng-bind=\"projectDescription(item)\"></span>\n            </ui-select-choices>\n          </ui-select>\n          <div class=\"project-actions\" ng-show=\"vis.dataService.currentProject.id\">\n            <button type=\"button\" ng-disabled=\"vis.dataService.loading\" ng-click=\"vis.createSubsequentTasks()\" class=\"btn btn-default\">\n              Create subsequent tasks\n            </button>\n            <button type=\"button\" ng-disabled=\"vis.dataService.loading\" ng-click=\"vis.showSlackActions()\" class=\"btn btn-default\">\n              Edit Slack users\n            </button>\n            <button type=\"button\" ng-disabled=\"vis.dataService.loading\" ng-click=\"vis.showProjectData()\" class=\"btn btn-default\">\n              View project data\n            </button>\n            <a ng-href=\"{{vis.dataService.data.project.admin_url}}\" ng-disabled=\"vis.dataService.loading\" target=\"_blank\">\n              <button type=\"button\" class=\"btn btn-default\">View in admin</button>\n            </a>\n            <button ng-click=\"vis.endProject()\" class=\"btn btn-danger\">Abort project</button>\n          </div>\n        </div>\n      </div>\n      <div class=\"row\">\n        <div class=\"col-lg-12 col-md-12 col-sm-12\">\n          <div class=\"vis-wrapper\" ng-show=\"vis.dataService.currentProject.id\">\n            <div class=\"overlay\" ng-if=\"vis.dataService.loading\">\n              <div class=\"spinner\"></div>\n            </div>\n            <div class=\"freeze-pane-left\">\n              <div class=\"scale-buttons\">\n                <button ng-click=\"vis.axis.relativeTime = !vis.axis.relativeTime; vis.draw()\"\n                        class=\"btn btn-default btn-sm\">\n                  Switch to {{vis.axis.relativeTime ? 'local' : 'relative'}} time\n                </button>\n                <button ng-click=\"vis.params.scaleWidth = vis.params.scaleWidth / 1.1; vis.draw()\"\n                        class=\"btn btn-default btn-sm\">\n                  -\n                </button>\n                <button ng-click=\"vis.params.scaleWidth = vis.params.scaleWidth * 1.1; vis.draw()\"\n                        class=\"btn btn-default btn-sm\">\n                  +\n                </button>\n              </div>\n              <div class=\"task-names\"></div>\n            </div>\n            <div class=\"svg-wrapper\"></div>\n          </div>\n        </div>\n      </div>\n    </div>\n  </section>\n</div>\n";
+module.exports = "<div class=\"project-management\">\n  <div class=\"overlay\" ng-if=\"vis.dataService.loading\">\n    <div class=\"spinner\"></div>\n  </div>\n  <section class=\"section-panel\">\n    <div class=\"container-fluid\">\n      <div class=\"row padded\">\n        <div class=\"col-lg-12 col-md-12 col-sm-12\">\n          <ui-select class=\"project-description\" ng-model=\"vis.dataService.currentProject\"\n              ng-change=\"vis.dataService.setSelectedProject()\"\n              ng-disabled=\"vis.dataService.loading\">\n            <ui-select-match>\n              <span ng-bind=\"projectDescription($select.selected)\"></span>\n            </ui-select-match>\n            <ui-select-choices repeat=\"item in (vis.dataService.allProjects | toArray | filter: $select.search) track by item.id\">\n              <span ng-bind=\"projectDescription(item)\"></span>\n            </ui-select-choices>\n          </ui-select>\n          <div class=\"project-actions\" ng-show=\"vis.dataService.currentProject.id\">\n            <button type=\"button\" ng-disabled=\"vis.dataService.loading\" ng-click=\"vis.createSubsequentTasks()\" class=\"btn btn-default\">\n              Create subsequent tasks\n            </button>\n            <button type=\"button\" ng-disabled=\"vis.dataService.loading\" ng-click=\"vis.showSlackActions()\" class=\"btn btn-default\">\n              Edit Slack users\n            </button>\n            <button type=\"button\" ng-disabled=\"vis.dataService.loading\" ng-click=\"vis.showProjectData()\" class=\"btn btn-default\">\n              View project data\n            </button>\n            <a ng-href=\"{{vis.dataService.data.project.admin_url}}\" ng-disabled=\"vis.dataService.loading\" target=\"_blank\">\n              <button type=\"button\" class=\"btn btn-default\">View in admin</button>\n            </a>\n            <button ng-click=\"vis.endProject()\" class=\"btn btn-danger\">Abort project</button>\n          </div>\n        </div>\n      </div>\n      <div class=\"row\">\n        <div class=\"col-lg-12 col-md-12 col-sm-12\">\n          <div class=\"vis-wrapper\" ng-show=\"vis.dataService.currentProject.id\">\n            <div class=\"freeze-pane-left\">\n              <div class=\"scale-buttons\">\n                <button ng-click=\"vis.axis.relativeTime = !vis.axis.relativeTime; vis.draw()\"\n                        class=\"btn btn-default btn-sm\">\n                  Switch to {{vis.axis.relativeTime ? 'local' : 'relative'}} time\n                </button>\n                <button ng-click=\"vis.params.scaleWidth = vis.params.scaleWidth / 1.1; vis.draw()\"\n                        class=\"btn btn-default btn-sm\">\n                  -\n                </button>\n                <button ng-click=\"vis.params.scaleWidth = vis.params.scaleWidth * 1.1; vis.draw()\"\n                        class=\"btn btn-default btn-sm\">\n                  +\n                </button>\n              </div>\n              <div class=\"task-names\"></div>\n            </div>\n            <div class=\"svg-wrapper\"></div>\n          </div>\n        </div>\n      </div>\n    </div>\n  </section>\n</div>\n";
 
 /***/ })
 /******/ ]);

--- a/orchestra/static/orchestra/common/css/_common.scss
+++ b/orchestra/static/orchestra/common/css/_common.scss
@@ -61,8 +61,16 @@ $main-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helveti
     border-bottom: 1px solid $black;
     border-right: 1px solid $black;
     border-radius: 50%;
-
     content: "";
     animation: spin .75s linear infinite;
+  }
+}
+
+@keyframes spin {
+  from {
+    transform:rotate(0deg);
+  }
+  to {
+     transform:rotate(360deg);
   }
 }

--- a/orchestra/static/orchestra/common/js/orchestra_api.es6.js
+++ b/orchestra/static/orchestra/common/js/orchestra_api.es6.js
@@ -16,9 +16,9 @@ export default function orchestraApi ($http) {
       })
     },
 
-    completeAndSkipTask: function (task) {
+    completeAndSkipTask: function (taskId) {
       return $http.post(getApiUrl('complete_and_skip_task'), {
-        'task_id': task.id
+        'task_id': taskId
       })
     },
 

--- a/orchestra/static/orchestra/dashboard/tasktable.directive.es6.js
+++ b/orchestra/static/orchestra/dashboard/tasktable.directive.es6.js
@@ -12,10 +12,10 @@ export default function tasktable () {
     },
     controllerAs: 'vm',
     bindToController: true,
-    controller: function ($location, $timeout, orchestraTasks) {
+    controller: function ($location, $timeout, $window, orchestraTasks) {
       const vm = this
       vm.openTask = (task) => {
-        $location.path(`task/${task.id}`)
+        $window.open(`task/${task.id}`, '_blank')
       }
       // Surface service to interpolator
       vm.orchestraTasks = orchestraTasks

--- a/orchestra/static/orchestra/project-management/data-service.es6.js
+++ b/orchestra/static/orchestra/project-management/data-service.es6.js
@@ -20,10 +20,12 @@ export default function dataService ($location, $rootScope, $route, orchestraApi
     },
     getAllProjects: function () {
       var dataService = this
+      dataService.loading = true
       dataService.ready = orchestraApi.allProjects().then(function (response) {
         response.data.forEach(function (project) {
           dataService.allProjects[project.id] = project
         })
+        dataService.loading = false
       })
       return dataService.ready
     },

--- a/orchestra/static/orchestra/project-management/project-management.html
+++ b/orchestra/static/orchestra/project-management/project-management.html
@@ -1,4 +1,7 @@
 <div class="project-management">
+  <div class="overlay" ng-if="vis.dataService.loading">
+    <div class="spinner"></div>
+  </div>
   <section class="section-panel">
     <div class="container-fluid">
       <div class="row padded">
@@ -33,9 +36,6 @@
       <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12">
           <div class="vis-wrapper" ng-show="vis.dataService.currentProject.id">
-            <div class="overlay" ng-if="vis.dataService.loading">
-              <div class="spinner"></div>
-            </div>
             <div class="freeze-pane-left">
               <div class="scale-buttons">
                 <button ng-click="vis.axis.relativeTime = !vis.axis.relativeTime; vis.draw()"

--- a/orchestra/static/orchestra/project-management/project-management.scss
+++ b/orchestra/static/orchestra/project-management/project-management.scss
@@ -49,6 +49,26 @@
   font-size: 1.5rem;
   position: relative;
 
+  .overlay {
+    position: absolute;
+    top: 0;
+    left: 20px;
+    right: 20px;
+    bottom: 0;
+    background-color: white;
+    opacity: 0.75;
+    z-index: 100;
+    .spinner {
+        position: absolute;
+        width: 40px;
+        height: 40px;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        @extend %loading-spinner;
+    }
+  }
+
   .project-description.ui-select-bootstrap {
     margin: 10px 0;
     > .ui-select-match > .btn {
@@ -119,28 +139,6 @@
     position: relative;
     margin-bottom: 75px;
     min-height: 200px;
-
-    .overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background-color: white;
-      opacity: 0.75;
-      z-index: 100;
-
-      .spinner {
-        position: absolute;
-        width: 40px;
-        height: 40px;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        @extend %loading-spinner;
-      }
-    }
-
     .svg-wrapper {
       overflow-x: auto;
 

--- a/orchestra/static/orchestra/project-management/tasks-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/tasks-vis.es6.js
@@ -367,7 +367,7 @@ export default function tasksVis (
         'corrupted/unrecoverable state.')) {
         return
       }
-      orchestraApi.completeAndSkipTask(task)
+      orchestraApi.completeAndSkipTask(task.id)
         .then(function () {
           dataService.updateData()
         }, function (response) {

--- a/orchestra/static/orchestra/team-info/team-info-card.directive.es6.js
+++ b/orchestra/static/orchestra/team-info/team-info-card.directive.es6.js
@@ -8,13 +8,16 @@ export default function teamInfoCard (orchestraApi) {
     template,
     restrict: 'E',
     scope: {
-      projectId: '=',
-      isProjectAdmin: '='
+      taskAssignment: '=',
     },
     controllerAs: 'teamInfoCard',
     bindToController: true,
     controller: ($scope) => {
       const teamInfoCard = $scope.teamInfoCard
+      teamInfoCard.projectId = teamInfoCard.taskAssignment.project.id
+      teamInfoCard.step = teamInfoCard.taskAssignment.step
+      teamInfoCard.isProjectAdmin = teamInfoCard.taskAssignment.is_project_admin
+
       teamInfoCard.loadTeamInfo = () => {
         orchestraApi.projectInformation(teamInfoCard.projectId)
           .then(response => {
@@ -31,6 +34,7 @@ export default function teamInfoCard (orchestraApi) {
               if (task) {
                 teamInfoCard.assignments = teamInfoCard.assignments.concat(task.assignments.map(a => {
                   return {
+                    stepSlug,
                     role: teamInfoCard.steps[stepSlug].name,
                     worker: a.worker,
                     recordedTime: moment.duration(a.recorded_work_time, 'seconds').roundMinute().humanizeUnits(),

--- a/orchestra/static/orchestra/team-info/team-info-card.directive.es6.js
+++ b/orchestra/static/orchestra/team-info/team-info-card.directive.es6.js
@@ -8,7 +8,8 @@ export default function teamInfoCard (orchestraApi) {
     template,
     restrict: 'E',
     scope: {
-      projectId: '='
+      projectId: '=',
+      isProjectAdmin: '='
     },
     controllerAs: 'teamInfoCard',
     bindToController: true,

--- a/orchestra/static/orchestra/team-info/team-info-card.directive.es6.js
+++ b/orchestra/static/orchestra/team-info/team-info-card.directive.es6.js
@@ -8,7 +8,7 @@ export default function teamInfoCard (orchestraApi) {
     template,
     restrict: 'E',
     scope: {
-      taskAssignment: '=',
+      taskAssignment: '='
     },
     controllerAs: 'teamInfoCard',
     bindToController: true,

--- a/orchestra/static/orchestra/team-info/team-info-card.html
+++ b/orchestra/static/orchestra/team-info/team-info-card.html
@@ -4,6 +4,12 @@
       <div class="col-lg-12 col-md-12 col-sm-12">
         <h3>
           Team info
+          <a class="btn"
+             ng-if="teamInfoCard.isProjectAdmin"
+             ng-href="project/{{teamInfoCard.projectId}}"
+             target="_blank">
+            Project Management
+          </a>
         </h3>
       </div>
     </div>

--- a/orchestra/static/orchestra/team-info/team-info-card.html
+++ b/orchestra/static/orchestra/team-info/team-info-card.html
@@ -21,6 +21,7 @@
             <th>Username</th>
             <th>Name</th>
             <th>Recorded time spent</th>
+            <th>Status</th>
           </thead>
           <tbody>
             <tr ng-repeat="assignment in teamInfoCard.assignments">
@@ -28,6 +29,16 @@
               <td>{{assignment.worker.username}}</td>
               <td>{{assignment.worker.first_name}} {{assignment.worker.last_name}}</td>
               <td>{{assignment.recordedTime}}</td>
+              <td>
+                {{assignment.status}}
+                <button type="submit"
+                        class="btn btn-secondary btn-sm"
+                        ng-if="teamInfoCard.isProjectAdmin &&
+                               assignment.status == 'Processing'"
+                        ng-click="teamInfoCard.submitTask(assignment.task_id)">
+                  Submit
+                </button>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/orchestra/static/orchestra/team-info/team-info-card.html
+++ b/orchestra/static/orchestra/team-info/team-info-card.html
@@ -32,9 +32,10 @@
               <td>
                 {{assignment.status}}
                 <button type="submit"
-                        class="btn btn-secondary btn-sm"
+                        class="btn btn-default btn-sm"
                         ng-if="teamInfoCard.isProjectAdmin &&
-                               assignment.status == 'Processing'"
+                               assignment.status == 'Processing' &&
+                               assignment.stepSlug != teamInfoCard.step.slug"
                         ng-click="teamInfoCard.submitTask(assignment.task_id)">
                   Submit
                 </button>

--- a/orchestra/tests/helpers/fixtures.py
+++ b/orchestra/tests/helpers/fixtures.py
@@ -291,7 +291,6 @@ def setup_models(test_case):
         'creation_policy': 'creation_policy_workflow',
         'next_todo_proj': 'test_workflow',
         'sanitybot': 'sanitybot_workflow',
-        'review_nearly_complete_proj': 'test_workflow',
     }
 
     # Task generation data
@@ -350,14 +349,6 @@ def setup_models(test_case):
             'assignments': [
                 (5, {}, TaskAssignment.Status.PROCESSING)
             ]
-        },
-        'review_nearly_complete_task': {
-            'project_name': 'review_nearly_complete_proj',
-            'status': Task.Status.AWAITING_PROCESSING,
-            'assignments': [
-                (5, {}, TaskAssignment.Status.SUBMITTED),
-                (6, {}, TaskAssignment.Status.SUBMITTED),
-            ],
         },
     }
 

--- a/orchestra/tests/helpers/fixtures.py
+++ b/orchestra/tests/helpers/fixtures.py
@@ -353,11 +353,11 @@ def setup_models(test_case):
         },
         'review_nearly_complete_task': {
             'project_name': 'review_nearly_complete_proj',
-            'status': Task.Status.REVIEWING,
+            'status': Task.Status.AWAITING_PROCESSING,
             'assignments': [
                 (5, {}, TaskAssignment.Status.SUBMITTED),
                 (6, {}, TaskAssignment.Status.SUBMITTED),
-                (7, {}, TaskAssignment.Status.PROCESSING)
+                (7, {}, TaskAssignment.Status.SUBMITTED)
             ],
         },
     }

--- a/orchestra/tests/helpers/fixtures.py
+++ b/orchestra/tests/helpers/fixtures.py
@@ -291,6 +291,7 @@ def setup_models(test_case):
         'creation_policy': 'creation_policy_workflow',
         'next_todo_proj': 'test_workflow',
         'sanitybot': 'sanitybot_workflow',
+        'review_nearly_complete_proj': 'test_workflow',
     }
 
     # Task generation data
@@ -349,7 +350,16 @@ def setup_models(test_case):
             'assignments': [
                 (5, {}, TaskAssignment.Status.PROCESSING)
             ]
-        }
+        },
+        'review_nearly_complete_task': {
+            'project_name': 'review_nearly_complete_proj',
+            'status': Task.Status.REVIEWING,
+            'assignments': [
+                (5, {}, TaskAssignment.Status.SUBMITTED),
+                (6, {}, TaskAssignment.Status.SUBMITTED),
+                (7, {}, TaskAssignment.Status.PROCESSING)
+            ],
+        },
     }
 
     # Create the objects

--- a/orchestra/tests/helpers/fixtures.py
+++ b/orchestra/tests/helpers/fixtures.py
@@ -357,7 +357,6 @@ def setup_models(test_case):
             'assignments': [
                 (5, {}, TaskAssignment.Status.SUBMITTED),
                 (6, {}, TaskAssignment.Status.SUBMITTED),
-                (7, {}, TaskAssignment.Status.SUBMITTED)
             ],
         },
     }

--- a/orchestra/tests/test_dashboard.py
+++ b/orchestra/tests/test_dashboard.py
@@ -521,6 +521,7 @@ class DashboardTestCase(OrchestraTransactionTestCase):
             'step': {'slug': 'step1', 'name': 'The first step'},
             'is_reviewer': is_reviewer,
             'is_read_only': is_read_only,
+            'is_project_admin': False,
             'worker': {
                 'username': worker.user.username,
                 'first_name': worker.user.first_name,

--- a/orchestra/tests/workflows/test_load.py
+++ b/orchestra/tests/workflows/test_load.py
@@ -143,16 +143,6 @@ class LoadWorkflowTestCase(OrchestraTestCase):
         v1_data['steps'][1]['creation_depends_on'] = (
             step_2_create_dependencies[:-1])
 
-        # Even with --force, can't change a step's submission dependencies.
-        step_3_submit_dependencies = v1_data['steps'][2][
-            'submission_depends_on']
-        step_3_submit_dependencies.append('s1')
-        with self.assertRaisesMessage(WorkflowError, topology_change_err_msg):
-            with transaction.atomic():
-                load_workflow_version(v1_data, workflow, force=True)
-        v1_data['steps'][2]['submission_depends_on'] = (
-            step_3_submit_dependencies[:-1])
-
         # Otherwise, --force should reload versions correctly.
         with transaction.atomic():
             load_workflow_version(v1_data, workflow, force=True)

--- a/orchestra/utils/task_lifecycle.py
+++ b/orchestra/utils/task_lifecycle.py
@@ -419,6 +419,7 @@ def get_task_overview_for_worker(task_id, worker):
     """
     task = Task.objects.get(id=task_id)
     task_details = get_task_details(task_id)
+    task_details['is_project_admin'] = worker.is_project_admin()
 
     if task.is_worker_assigned(worker):
         task_assignment = TaskAssignment.objects.get(worker=worker, task=task)

--- a/orchestra/utils/task_lifecycle.py
+++ b/orchestra/utils/task_lifecycle.py
@@ -328,7 +328,6 @@ def complete_and_skip_task(task_id):
         for assignment in task.assignments.all():
             assignment.status = TaskAssignment.Status.SUBMITTED
             assignment.save()
-        create_subsequent_tasks(task.project)
     return task
 
 

--- a/orchestra/utils/task_lifecycle.py
+++ b/orchestra/utils/task_lifecycle.py
@@ -301,7 +301,9 @@ def reassign_assignment(worker_id, assignment_id,
 @transaction.atomic
 def complete_and_skip_task(task_id):
     """
-    Marks a task and its assignments as complete and creates subsequent tasks.
+    Submits a task on behalf of the worker working on it. If the task
+    isn't assigned to a worker, marks it and its assignments as
+    complete and creates subsequent tasks.
 
     Args:
         task_id (int):
@@ -310,11 +312,11 @@ def complete_and_skip_task(task_id):
     Returns:
         task (orchestra.models.Task):
             The completed and skipped task.
+
     """
     task = Task.objects.get(id=task_id)
     assignment = current_assignment(task)
     if assignment and assignment.worker:
-        # TODO(marcua): iteration status and task data
         task_data = assignment.in_progress_task_data or {}
         task_data.update(_orchestra_internal={'complete_and_skip_task': True})
         submit_task(

--- a/orchestra/utils/tests/test_task_lifecycle.py
+++ b/orchestra/utils/tests/test_task_lifecycle.py
@@ -349,6 +349,7 @@ class BasicTaskLifeCycleTestCase(OrchestraTransactionTestCase):
             'superuser', 'superuser@b12.io', 'test-password')
         superworker = Worker.objects.create(user=superuser)
         data = get_task_overview_for_worker(task.id, superworker)
+        expected['is_project_admin'] = True
         self.assertEqual(data, expected)
 
     def test_task_assignment_saving(self):

--- a/orchestra/utils/tests/test_task_lifecycle.py
+++ b/orchestra/utils/tests/test_task_lifecycle.py
@@ -335,6 +335,7 @@ class BasicTaskLifeCycleTestCase(OrchestraTransactionTestCase):
             'assignment_id': task.assignments.get(worker=self.workers[0]).id,
             'is_reviewer': False,
             'is_read_only': True,
+            'is_project_admin': False,
             'worker': {
                 'username': self.workers[0].user.username,
                 'first_name': self.workers[0].user.first_name,

--- a/orchestra/workflow/load.py
+++ b/orchestra/workflow/load.py
@@ -182,12 +182,6 @@ def load_workflow_version(version_data, workflow, force=False):
         _set_step_dependencies(step, step_data, 'creation_depends_on', Step,
                                workflow_version=version)
 
-        # Set step submission dependencies.
-        _verify_dependencies_not_updated(
-            step_data,
-            'submission_depends_on',
-            old_submission_dependencies.get(step_slug)
-        )
         _set_step_dependencies(step, step_data, 'submission_depends_on', Step,
                                workflow_version=version)
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "yargs": "^4.3.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "webpack --config webpack.config.js --progress --color --watch"
   },
   "author": "Team B12"
 }


### PR DESCRIPTION
This PR does the following:
* Tasks clicked in the dashboard open in a new tab
* Passes whether the current worker is in the project admin group from the backend to the frontend
* Makes project management load faster and display a loading spinner while loading
* Cleans up the "complete and skip" logic that's used by project admins to submit tasks on behalf of other workers.
* For project admins, adds the following to the team information card:
  * Adds a project management button that opens up this task's project management screen
  * Adds a task status column to each assignment's row, and, for tasks that are being processed by a worker, adds a "submit" button
* A yarn/npm convenience one-liner for dev mode (call `yarn dev`).
* A small update to our workflow loading logic to not stop workflow reloads if a submit dependency changes.
