### PR TITLE
Fix minor readonly and submission bugs

### DIFF
--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -42609,7 +42609,11 @@ function orchestraService() {
       var success = true;
       registered[signalType] = registered[signalType] || [];
       registered[signalType].forEach(function (callback) {
-        success = callback() && success;
+        // Explicitly check for falsiness in case callback returns
+        // undefined.
+        if (callback() === false) {
+          success = false;
+        }
       });
       return success;
     }
@@ -58988,8 +58992,8 @@ function TaskController($location, $scope, $routeParams, $http, $rootScope, auto
         });
       });
 
+      requiredFields.setup(vm);
       if (!vm.is_read_only) {
-        requiredFields.setup(vm);
         $scope.$watch('vm.taskAssignment.task.data', function (newVal, oldVal) {
           // Ensure save fired at initialization
           // [http://stackoverflow.com/a/18915585]
@@ -59036,7 +59040,7 @@ function TaskController($location, $scope, $routeParams, $http, $rootScope, auto
       vm.autoSaver.cancel();
       orchestraService.signals.fireSignal('submit.success');
       orchestraTasks.updateTasks();
-      $location.path('/timecard');
+      $location.path('/');
     }).error(function (data, status, headers, config) {
       orchestraService.signals.fireSignal('submit.error');
       window.alert(data.message);

--- a/orchestra/static/orchestra/common/js/orchestra.services.es6.js
+++ b/orchestra/static/orchestra/common/js/orchestra.services.es6.js
@@ -48,7 +48,11 @@ export function orchestraService () {
       var success = true
       registered[signalType] = registered[signalType] || []
       registered[signalType].forEach(function (callback) {
-        success = callback() && success
+        // Explicitly check for falsiness in case callback returns
+        // undefined.
+        if (callback() === false) {
+          success = false
+        }
       })
       return success
     }

--- a/orchestra/static/orchestra/task/task.controller.es6.js
+++ b/orchestra/static/orchestra/task/task.controller.es6.js
@@ -24,8 +24,8 @@ export default function TaskController (
         })
       })
 
+      requiredFields.setup(vm)
       if (!vm.is_read_only) {
-        requiredFields.setup(vm)
         $scope.$watch('vm.taskAssignment.task.data', function (newVal, oldVal) {
           // Ensure save fired at initialization
           // [http://stackoverflow.com/a/18915585]
@@ -80,7 +80,7 @@ export default function TaskController (
         vm.autoSaver.cancel()
         orchestraService.signals.fireSignal('submit.success')
         orchestraTasks.updateTasks()
-        $location.path('/timecard')
+        $location.path('/')
       })
       .error(function (data, status, headers, config) {
         orchestraService.signals.fireSignal('submit.error')


### PR DESCRIPTION
- Redirect to the dashboard when a task is submitted
- Set up signals even on readonly tasks so we don't get undefined exceptions
- Don't get stuck on signals that don't return true/false.