### PR TITLE
Added a button to copy QA summary from Todo QA section

### DIFF
--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -61625,7 +61625,7 @@ function qa(orchestraApi) {
         summary = summary || '';
         todos.forEach(function (todo) {
           summary = todoQa.commentSummary(todo.items, summary);
-          if (todo.qa && !todo.qa.approved && todo.qa.comment) {
+          if (todo.qa && todo.qa.comment) {
             summary = '*Todo*: ' + todo.description + '\n*Comment*: ' + todo.qa.comment + '\n\n' + summary;
           }
         });
@@ -61697,7 +61697,7 @@ function qa(orchestraApi) {
 /* 212 */
 /***/ (function(module, exports) {
 
-module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          QA\n          <button class=\"btn\" ng-if=\"todoQa.todos.length\" ng-click=\"todoQa.copyToClipboard(todoQa.qaSummary())\">\n              Copy QA Summary\n          </button>\n        </h3>\n      </div>\n    </div>\n\n    <div class=\"row section-body\" ng-if=\"todoQa.ready\">\n      <div class=\"col-sm-12\">\n        <todo-qa-list\n        todos=\"todoQa.todos\"\n        approve-todo=\"todoQa.approveTodo\"\n        disapprove-todo=\"todoQa.disapproveTodo\"\n        update-todo-qa-comment=\"todoQa.updateTodoQaComment\"\n        ></todo-qa-list>\n      </div>\n    </div>\n\n  </div>\n</section>\n";
+module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          QA\n          <button class=\"btn\" ng-if=\"todoQa.todos.length\" ng-click=\"todoQa.copyToClipboard(todoQa.qaSummary())\">\n              Copy QA summary\n          </button>\n        </h3>\n      </div>\n    </div>\n\n    <div class=\"row section-body\" ng-if=\"todoQa.ready\">\n      <div class=\"col-sm-12\">\n        <todo-qa-list\n        todos=\"todoQa.todos\"\n        approve-todo=\"todoQa.approveTodo\"\n        disapprove-todo=\"todoQa.disapproveTodo\"\n        update-todo-qa-comment=\"todoQa.updateTodoQaComment\"\n        ></todo-qa-list>\n      </div>\n    </div>\n\n  </div>\n</section>\n";
 
 /***/ }),
 /* 213 */

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -61596,7 +61596,7 @@ var _todoQa2 = _interopRequireDefault(_todoQa);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function qa() {
+function qa(orchestraApi) {
   return {
     template: _todoQa2.default,
     restrict: 'E',
@@ -61609,6 +61609,7 @@ function qa() {
     controller: function controller(todoApi, todoQaApi, $scope) {
       var todoQa = this;
       todoQa.todos = [];
+      todoQa.project = null;
       todoQa.ready = false;
 
       todoQa.copyToClipboard = function (str) {
@@ -61624,7 +61625,7 @@ function qa() {
         summary = summary || '';
         todos.forEach(function (todo) {
           summary = todoQa.commentSummary(todo.items, summary);
-          if (todo.qa && todo.qa.comment) {
+          if (todo.qa && !todo.qa.approved && todo.qa.comment) {
             summary = '*Todo*: ' + todo.description + '\n*Comment*: ' + todo.qa.comment + '\n\n' + summary;
           }
         });
@@ -61633,7 +61634,11 @@ function qa() {
 
       todoQa.qaSummary = function () {
         var commentSummary = todoQa.commentSummary(todoQa.todos);
-        return '*Feedback on project*\n\n' + commentSummary;
+        if (commentSummary.length) {
+          return '*Feedback on ' + todoQa.project.short_description + '*\n\n' + commentSummary;
+        } else {
+          return '*No feedback on ' + todoQa.project.short_description + '*';
+        }
       };
 
       todoQa.updateTodoQaComment = function (todo) {
@@ -61677,10 +61682,12 @@ function qa() {
           return !obj.parent_todo;
         });
       };
-
-      todoApi.list(todoQa.projectId).then(function (todos) {
-        todoQa.todos = todoQa.transformToTree(todos);
-        todoQa.ready = true;
+      orchestraApi.projectInformation(todoQa.projectId).then(function (response) {
+        todoQa.project = response.data.project;
+        todoApi.list(todoQa.projectId).then(function (todos) {
+          todoQa.todos = todoQa.transformToTree(todos);
+          todoQa.ready = true;
+        });
       });
     }
   };
@@ -61690,7 +61697,7 @@ function qa() {
 /* 212 */
 /***/ (function(module, exports) {
 
-module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          QA\n          <button class=\"btn\" ng-click=\"todoQa.copyToClipboard(todoQa.qaSummary())\">\n              Copy QA Summary\n          </button>\n        </h3>\n      </div>\n    </div>\n\n    <div class=\"row section-body\" ng-if=\"todoQa.ready\">\n      <div class=\"col-sm-12\">\n        <todo-qa-list\n        todos=\"todoQa.todos\"\n        approve-todo=\"todoQa.approveTodo\"\n        disapprove-todo=\"todoQa.disapproveTodo\"\n        update-todo-qa-comment=\"todoQa.updateTodoQaComment\"\n        ></todo-qa-list>\n      </div>\n    </div>\n\n  </div>\n</section>\n";
+module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          QA\n          <button class=\"btn\" ng-if=\"todoQa.todos.length\" ng-click=\"todoQa.copyToClipboard(todoQa.qaSummary())\">\n              Copy QA Summary\n          </button>\n        </h3>\n      </div>\n    </div>\n\n    <div class=\"row section-body\" ng-if=\"todoQa.ready\">\n      <div class=\"col-sm-12\">\n        <todo-qa-list\n        todos=\"todoQa.todos\"\n        approve-todo=\"todoQa.approveTodo\"\n        disapprove-todo=\"todoQa.disapproveTodo\"\n        update-todo-qa-comment=\"todoQa.updateTodoQaComment\"\n        ></todo-qa-list>\n      </div>\n    </div>\n\n  </div>\n</section>\n";
 
 /***/ }),
 /* 213 */

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -61620,15 +61620,20 @@ function qa() {
         document.body.removeChild(el);
       };
 
-      todoQa.summary = function (todos, summary) {
+      todoQa.commentSummary = function (todos, summary) {
         summary = summary || '';
         todos.forEach(function (todo) {
-          summary = todoQa.summary(todo.items, summary);
+          summary = todoQa.commentSummary(todo.items, summary);
           if (todo.qa && todo.qa.comment) {
             summary = '*Todo*: ' + todo.description + '\n*Comment*: ' + todo.qa.comment + '\n\n' + summary;
           }
         });
         return summary;
+      };
+
+      todoQa.qaSummary = function () {
+        var commentSummary = todoQa.commentSummary(todoQa.todos);
+        return '*Feedback on project*\n\n' + commentSummary;
       };
 
       todoQa.updateTodoQaComment = function (todo) {
@@ -61685,7 +61690,7 @@ function qa() {
 /* 212 */
 /***/ (function(module, exports) {
 
-module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          QA\n          <button class=\"btn\" ng-click=\"todoQa.copyToClipboard(todoQa.summary(todoQa.todos))\">\n              Copy QA Summary\n          </button>\n        </h3>\n      </div>\n    </div>\n\n    <div class=\"row section-body\" ng-if=\"todoQa.ready\">\n      <div class=\"col-sm-12\">\n        <todo-qa-list\n        todos=\"todoQa.todos\"\n        approve-todo=\"todoQa.approveTodo\"\n        disapprove-todo=\"todoQa.disapproveTodo\"\n        update-todo-qa-comment=\"todoQa.updateTodoQaComment\"\n        ></todo-qa-list>\n      </div>\n    </div>\n\n  </div>\n</section>\n";
+module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          QA\n          <button class=\"btn\" ng-click=\"todoQa.copyToClipboard(todoQa.qaSummary())\">\n              Copy QA Summary\n          </button>\n        </h3>\n      </div>\n    </div>\n\n    <div class=\"row section-body\" ng-if=\"todoQa.ready\">\n      <div class=\"col-sm-12\">\n        <todo-qa-list\n        todos=\"todoQa.todos\"\n        approve-todo=\"todoQa.approveTodo\"\n        disapprove-todo=\"todoQa.disapproveTodo\"\n        update-todo-qa-comment=\"todoQa.updateTodoQaComment\"\n        ></todo-qa-list>\n      </div>\n    </div>\n\n  </div>\n</section>\n";
 
 /***/ }),
 /* 213 */

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -61611,6 +61611,26 @@ function qa() {
       todoQa.todos = [];
       todoQa.ready = false;
 
+      todoQa.copyToClipboard = function (str) {
+        var el = document.createElement('textarea');
+        el.value = str;
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand('copy');
+        document.body.removeChild(el);
+      };
+
+      todoQa.summary = function (todos, summary) {
+        summary = summary || '';
+        todos.forEach(function (todo) {
+          summary = todoQa.summary(todo.items, summary);
+          if (todo.qa && todo.qa.comment) {
+            summary = '*Todo*: ' + todo.description + '\n*Comment*: ' + todo.qa.comment + '\n\n' + summary;
+          }
+        });
+        return summary;
+      };
+
       todoQa.updateTodoQaComment = function (todo) {
         todoQaApi.update(todo.qa);
       };
@@ -61665,7 +61685,7 @@ function qa() {
 /* 212 */
 /***/ (function(module, exports) {
 
-module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          QA\n        </h3>\n      </div>\n    </div>\n\n    <div class=\"row section-body\" ng-if=\"todoQa.ready\">\n      <div class=\"col-sm-12\">\n        <todo-qa-list\n        todos=\"todoQa.todos\"\n        approve-todo=\"todoQa.approveTodo\"\n        disapprove-todo=\"todoQa.disapproveTodo\"\n        update-todo-qa-comment=\"todoQa.updateTodoQaComment\"\n        ></todo-qa-list>\n      </div>\n    </div>\n\n  </div>\n</section>\n";
+module.exports = "<section class=\"section-panel todo-list\">\n  <div class=\"container-fluid\">\n\n    <div class=\"row section-header\">\n      <div class=\"col-lg-12 col-md-12 col-sm-12\">\n        <h3>\n          QA\n          <button class=\"btn\" ng-click=\"todoQa.copyToClipboard(todoQa.summary(todoQa.todos))\">\n              Copy QA Summary\n          </button>\n        </h3>\n      </div>\n    </div>\n\n    <div class=\"row section-body\" ng-if=\"todoQa.ready\">\n      <div class=\"col-sm-12\">\n        <todo-qa-list\n        todos=\"todoQa.todos\"\n        approve-todo=\"todoQa.approveTodo\"\n        disapprove-todo=\"todoQa.disapproveTodo\"\n        update-todo-qa-comment=\"todoQa.updateTodoQaComment\"\n        ></todo-qa-list>\n      </div>\n    </div>\n\n  </div>\n</section>\n";
 
 /***/ }),
 /* 213 */

--- a/orchestra/static/orchestra/todos/todo-qa.directive.es6.js
+++ b/orchestra/static/orchestra/todos/todo-qa.directive.es6.js
@@ -25,15 +25,20 @@ export default function qa () {
         document.body.removeChild(el)
       }
 
-      todoQa.summary = (todos, summary) => {
+      todoQa.commentSummary = (todos, summary) => {
         summary = summary || ''
         todos.forEach((todo) => {
-          summary = todoQa.summary(todo.items, summary)
+          summary = todoQa.commentSummary(todo.items, summary)
           if (todo.qa && todo.qa.comment) {
-            summary = '*Todo*: ' + todo.description + '\n*Comment*: ' + todo.qa.comment + '\n\n' + summary
+            summary = `*Todo*: ${todo.description}\n*Comment*: ${todo.qa.comment}\n\n${summary}`
           }
         })
         return summary
+      }
+
+      todoQa.qaSummary = () => {
+        const commentSummary = todoQa.commentSummary(todoQa.todos)
+        return `*Feedback on project*\n\n${commentSummary}`
       }
 
       todoQa.updateTodoQaComment = (todo) => {

--- a/orchestra/static/orchestra/todos/todo-qa.directive.es6.js
+++ b/orchestra/static/orchestra/todos/todo-qa.directive.es6.js
@@ -30,7 +30,7 @@ export default function qa (orchestraApi) {
         summary = summary || ''
         todos.forEach((todo) => {
           summary = todoQa.commentSummary(todo.items, summary)
-          if (todo.qa && !todo.qa.approved && todo.qa.comment) {
+          if (todo.qa && todo.qa.comment) {
             summary = `*Todo*: ${todo.description}\n*Comment*: ${todo.qa.comment}\n\n${summary}`
           }
         })

--- a/orchestra/static/orchestra/todos/todo-qa.directive.es6.js
+++ b/orchestra/static/orchestra/todos/todo-qa.directive.es6.js
@@ -16,6 +16,26 @@ export default function qa () {
       todoQa.todos = []
       todoQa.ready = false
 
+      todoQa.copyToClipboard = str => {
+        const el = document.createElement('textarea')
+        el.value = str
+        document.body.appendChild(el)
+        el.select()
+        document.execCommand('copy')
+        document.body.removeChild(el)
+      }
+
+      todoQa.summary = (todos, summary) => {
+        summary = summary || ''
+        todos.forEach((todo) => {
+          summary = todoQa.summary(todo.items, summary)
+          if (todo.qa && todo.qa.comment) {
+            summary = '*Todo*: ' + todo.description + '\n*Comment*: ' + todo.qa.comment + '\n\n' + summary
+          }
+        })
+        return summary
+      }
+
       todoQa.updateTodoQaComment = (todo) => {
         todoQaApi.update(todo.qa)
       }

--- a/orchestra/static/orchestra/todos/todo-qa.directive.es6.js
+++ b/orchestra/static/orchestra/todos/todo-qa.directive.es6.js
@@ -94,7 +94,7 @@ export default function qa (orchestraApi) {
             todoQa.todos = todoQa.transformToTree(todos)
             todoQa.ready = true
           })
-      })
+        })
     }
   }
 }

--- a/orchestra/static/orchestra/todos/todo-qa.html
+++ b/orchestra/static/orchestra/todos/todo-qa.html
@@ -6,7 +6,7 @@
         <h3>
           QA
           <button class="btn" ng-if="todoQa.todos.length" ng-click="todoQa.copyToClipboard(todoQa.qaSummary())">
-              Copy QA Summary
+              Copy QA summary
           </button>
         </h3>
       </div>

--- a/orchestra/static/orchestra/todos/todo-qa.html
+++ b/orchestra/static/orchestra/todos/todo-qa.html
@@ -5,7 +5,7 @@
       <div class="col-lg-12 col-md-12 col-sm-12">
         <h3>
           QA
-          <button class="btn" ng-click="todoQa.copyToClipboard(todoQa.qaSummary())">
+          <button class="btn" ng-if="todoQa.todos.length" ng-click="todoQa.copyToClipboard(todoQa.qaSummary())">
               Copy QA Summary
           </button>
         </h3>

--- a/orchestra/static/orchestra/todos/todo-qa.html
+++ b/orchestra/static/orchestra/todos/todo-qa.html
@@ -5,6 +5,9 @@
       <div class="col-lg-12 col-md-12 col-sm-12">
         <h3>
           QA
+          <button class="btn" ng-click="todoQa.copyToClipboard(todoQa.summary(todoQa.todos))">
+              Copy QA Summary
+          </button>
         </h3>
       </div>
     </div>

--- a/orchestra/static/orchestra/todos/todo-qa.html
+++ b/orchestra/static/orchestra/todos/todo-qa.html
@@ -5,7 +5,7 @@
       <div class="col-lg-12 col-md-12 col-sm-12">
         <h3>
           QA
-          <button class="btn" ng-click="todoQa.copyToClipboard(todoQa.summary(todoQa.todos))">
+          <button class="btn" ng-click="todoQa.copyToClipboard(todoQa.qaSummary())">
               Copy QA Summary
           </button>
         </h3>


### PR DESCRIPTION
Here is how the button looks like:
<img width="1384" alt="screen shot 2018-07-25 at 6 25 48 pm" src="https://user-images.githubusercontent.com/3481095/43230936-31403fba-9038-11e8-8675-20820a2d1d14.png">

The copied summary would like the following:
1. When there are one or more (approved/disapproved) todos with a comment
```
*Feedback on {project short description}*

*Todo*: Todo Description 1
*Comment*: Comment 1

*Todo*: Todo Description 2
*Comment*: Comment 2

*Todo*: Todo Description 3
*Comment*: Comment 3
```
2. Otherwise
```
*No feedback on {project short description}*
```