### PR TITLE
Adding a staffbot button to task assignment

### DIFF
--- a/orchestra/interface_api/project_management/tests/test_project_management_api.py
+++ b/orchestra/interface_api/project_management/tests/test_project_management_api.py
@@ -609,7 +609,7 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
     def test_staff_task(self, mock_staff, mock_restaff):
         # Staff a task with no assignment
         unassigned_task = self.tasks['awaiting_processing']
-        response = self.api_client.post(
+        self.api_client.post(
             reverse(
                 'orchestra:orchestra:project_management:staff_task'),
             json.dumps({
@@ -620,7 +620,7 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
 
         # Restaff a task with an assignment
         assigned_task = self.tasks['review_task']
-        response = self.api_client.post(
+        self.api_client.post(
             reverse(
                 'orchestra:orchestra:project_management:staff_task'),
             json.dumps({

--- a/orchestra/interface_api/project_management/tests/test_project_management_api.py
+++ b/orchestra/interface_api/project_management/tests/test_project_management_api.py
@@ -603,3 +603,28 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
                     audit['assignments'][i][
                         'iterations'][j]['change'] = iteration_change
         return audit
+
+    @patch('orchestra.interface_api.project_management.views.StaffBot.restaff')
+    @patch('orchestra.interface_api.project_management.views.StaffBot.staff')
+    def test_staff_task(self, mock_staff, mock_restaff):
+        # Staff a task with no assignment
+        unassigned_task = self.tasks['awaiting_processing']
+        response = self.api_client.post(
+            reverse(
+                'orchestra:orchestra:project_management:staff_task'),
+            json.dumps({
+                'task_id': unassigned_task.id
+            }),
+            content_type='application/json')
+        self.assertTrue(mock_staff.called)
+
+        # Restaff a task with an assignment
+        assigned_task = self.tasks['review_task']
+        response = self.api_client.post(
+            reverse(
+                'orchestra:orchestra:project_management:staff_task'),
+            json.dumps({
+                'task_id': assigned_task.id
+            }),
+            content_type='application/json')
+        self.assertTrue(mock_restaff.called)

--- a/orchestra/interface_api/project_management/tests/test_project_management_api.py
+++ b/orchestra/interface_api/project_management/tests/test_project_management_api.py
@@ -609,7 +609,7 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
     def test_staff_task(self, mock_staff, mock_restaff):
         # Staff a task with no assignment
         unassigned_task = self.tasks['awaiting_processing']
-        self.api_client.post(
+        response = self.api_client.post(
             reverse(
                 'orchestra:orchestra:project_management:staff_task'),
             json.dumps({
@@ -617,10 +617,13 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
             }),
             content_type='application/json')
         self.assertTrue(mock_staff.called)
+        self.assertEqual(response.status_code, 200)
+        is_restaff = load_encoded_json(response.content)['is_restaff']
+        self.assertFalse(is_restaff)
 
         # Restaff a task with an assignment
         assigned_task = self.tasks['review_task']
-        self.api_client.post(
+        response2 = self.api_client.post(
             reverse(
                 'orchestra:orchestra:project_management:staff_task'),
             json.dumps({
@@ -628,3 +631,6 @@ class ProjectManagementAPITestCase(OrchestraTestCase):
             }),
             content_type='application/json')
         self.assertTrue(mock_restaff.called)
+        self.assertEqual(response2.status_code, 200)
+        is_restaff2 = load_encoded_json(response2.content)['is_restaff']
+        self.assertTrue(is_restaff2)

--- a/orchestra/interface_api/project_management/urls.py
+++ b/orchestra/interface_api/project_management/urls.py
@@ -46,4 +46,8 @@ urlpatterns = [
     url(r'^revert_task/$',
         views.revert_task_api,
         name='revert_task'),
+
+    url(r'^staffbot_task/$',
+        views.staffbot_task,
+        name='staffbot_task'),
 ]

--- a/orchestra/interface_api/project_management/urls.py
+++ b/orchestra/interface_api/project_management/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
         views.revert_task_api,
         name='revert_task'),
 
-    url(r'^staffbot_task/$',
-        views.staffbot_task,
-        name='staffbot_task'),
+    url(r'^staff_task/$',
+        views.staff_task,
+        name='staff_task'),
 ]

--- a/orchestra/interface_api/project_management/views.py
+++ b/orchestra/interface_api/project_management/views.py
@@ -174,9 +174,12 @@ def staffbot_task(request):
         task = Task.objects.get(id=data.get('task_id'))
         request_cause = StaffBotRequest.RequestCause.USER.value
         bot = StaffBot()
-        is_restaff = current_assignment(task) is not None
+        assignment = current_assignment(task)
+        is_restaff = assignment is not None
         if is_restaff:
-            bot.restaff(task.id, request=request_cause)
+            username = assignment.worker.user.username
+            bot.restaff(task.id, username,
+                        request_cause=request_cause)
         else:
             bot.staff(task.id, request_cause=request_cause)
     except Exception as e:

--- a/orchestra/interface_api/project_management/views.py
+++ b/orchestra/interface_api/project_management/views.py
@@ -168,7 +168,7 @@ def set_project_status_api(request):
 
 
 @project_management_api_view
-def staffbot_task(request):
+def staff_task(request):
     data = load_encoded_json(request.body)
     errors = {}
     try:

--- a/orchestra/interface_api/project_management/views.py
+++ b/orchestra/interface_api/project_management/views.py
@@ -184,10 +184,9 @@ def staff_task(request):
         else:
             bot.staff(task.id, request_cause=request_cause)
     except Exception as e:
-        errors['error'] = str(e)
+        raise BadRequest(e)
     success = len(errors) == 0
     return {
         'success': success,
-        'errors': errors,
         'is_restaff': is_restaff
     }

--- a/orchestra/interface_api/project_management/views.py
+++ b/orchestra/interface_api/project_management/views.py
@@ -166,6 +166,7 @@ def set_project_status_api(request):
         raise BadRequest(e)
     return {'status': status, 'success': True}
 
+
 @project_management_api_view
 def staffbot_task(request):
     data = load_encoded_json(request.body)

--- a/orchestra/project_api/views.py
+++ b/orchestra/project_api/views.py
@@ -10,7 +10,6 @@ from orchestra.core.errors import WorkerCertificationError
 from orchestra.models import Project
 from orchestra.models import WorkerCertification
 from orchestra.models import Workflow
-from orchestra.models import Task
 from orchestra.project import create_project_with_tasks
 from orchestra.project_api.api import get_project_information
 from orchestra.utils.decorators import api_endpoint
@@ -19,7 +18,6 @@ from orchestra.utils.task_lifecycle import assign_task
 from orchestra.utils.notifications import message_experts_slack_group
 from orchestra.project_api.auth import OrchestraProjectAPIAuthentication
 from orchestra.project_api.auth import IsSignedUser
-from orchestra.bots.assignment_policies import staffbot_autoassign
 
 logger = logging.getLogger(__name__)
 
@@ -156,23 +154,3 @@ def message_project_team(request):
         ).format(project)
         raise BadRequest(error_message)
     return {'success': True}
-
-
-@api_endpoint(methods=['POST'],
-              permissions=(IsSignedUser,),
-              logger=logger,
-              auths=(OrchestraProjectAPIAuthentication,))
-def staffbot_assign_worker(request):
-    data = load_encoded_json(request.body)
-    errors = {}
-    try:
-        # PAOTODO: might need to manually take staff off the task
-        task = Task.objects.get(id=data.get('task_id'))
-        staffbot_autoassign(task)
-    except Exception as e:
-        errors['error'] = str(e)
-    success = len(errors) == 0
-    return {
-        'success': success,
-        'errors': errors,
-    }

--- a/orchestra/project_api/views.py
+++ b/orchestra/project_api/views.py
@@ -10,6 +10,7 @@ from orchestra.core.errors import WorkerCertificationError
 from orchestra.models import Project
 from orchestra.models import WorkerCertification
 from orchestra.models import Workflow
+from orchestra.models import Task
 from orchestra.project import create_project_with_tasks
 from orchestra.project_api.api import get_project_information
 from orchestra.utils.decorators import api_endpoint
@@ -18,6 +19,7 @@ from orchestra.utils.task_lifecycle import assign_task
 from orchestra.utils.notifications import message_experts_slack_group
 from orchestra.project_api.auth import OrchestraProjectAPIAuthentication
 from orchestra.project_api.auth import IsSignedUser
+from orchestra.bots.assignment_policies import staffbot_autoassign
 
 logger = logging.getLogger(__name__)
 
@@ -154,3 +156,23 @@ def message_project_team(request):
         ).format(project)
         raise BadRequest(error_message)
     return {'success': True}
+
+
+@api_endpoint(methods=['POST'],
+              permissions=(IsSignedUser,),
+              logger=logger,
+              auths=(OrchestraProjectAPIAuthentication,))
+def staffbot_assign_worker(request):
+    data = load_encoded_json(request.body)
+    errors = {}
+    try:
+        # PAOTODO: might need to manually take staff off the task
+        task = Task.objects.get(id=data.get('task_id'))
+        staffbot_autoassign(task)
+    except Exception as e:
+        errors['error'] = str(e)
+    success = len(errors) == 0
+    return {
+        'success': success,
+        'errors': errors,
+    }

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -58067,6 +58067,12 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
         var assignment = dataService.assignmentFromKey(assignmentKey);
         this.value = assignment.task.is_human ? assignment.worker.username : 'Machine';
       });
+
+      assignmentsMetaEnter.append('button').attr({
+        'class': 'btn btn-default btn-xs pull-right'
+      }).text('Staffbot').on('click', function () {
+        window.alert('staffbot!');
+      });
     },
     assign_task: function assign_task(task, inputEl) {
       /**

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -42516,6 +42516,13 @@ function orchestraApi($http) {
       });
     },
 
+    staffbotTask: function staffbotTask(task) {
+      console.log('staffbotTask');
+      return $http.post(getApiUrl('staffbot_task'), {
+        'task_id': task.id
+      });
+    },
+
     revertTask: function revertTask(taskId, iterationId, revertBefore, commit) {
       return $http.post(getApiUrl('revert_task'), {
         'task_id': taskId,
@@ -58070,8 +58077,9 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
 
       assignmentsMetaEnter.append('button').attr({
         'class': 'btn btn-default btn-xs pull-right'
-      }).text('Staffbot').on('click', function () {
-        window.alert('staffbot!');
+      }).text('Staffbot').on('click', function (assignmentKey) {
+        var assignment = dataService.assignmentFromKey(assignmentKey);
+        assignmentsVis.staffbotTask(assignment.task);
       });
     },
     assign_task: function assign_task(task, inputEl) {
@@ -58123,6 +58131,9 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
         inputEl.node().value = assignment.worker.username;
         assignment.reassigning = false;
       });
+    },
+    staffbotTask: function staffbotTask(task) {
+      orchestraApi.staffbotTask(task);
     }
   };
 }

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -58074,7 +58074,10 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
         this.value = assignment.task.is_human ? assignment.worker.username : 'Machine';
       });
 
-      assignmentsMetaEnter.append('button').attr({
+      assignmentsMetaEnter.filter(function (data) {
+        var assignment = dataService.assignmentFromKey(data);
+        return assignment.task.is_human && assignment.task.status !== 'Complete';
+      }).append('button').attr({
         'class': 'btn btn-default btn-xs pull-right'
       }).text(function (data) {
         var assignment = dataService.assignmentFromKey(data);

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -58076,7 +58076,10 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
 
       assignmentsMetaEnter.append('button').attr({
         'class': 'btn btn-default btn-xs pull-right'
-      }).text('Staffbot').on('click', function (assignmentKey) {
+      }).text(function (data) {
+        var assignment = dataService.assignmentFromKey(data);
+        return assignment.worker.id ? 'Restaff' : 'Staff';
+      }).on('click', function (assignmentKey) {
         var assignment = dataService.assignmentFromKey(assignmentKey);
         assignmentsVis.staffTask(assignment.task, d3.select(this));
       });

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -42516,8 +42516,8 @@ function orchestraApi($http) {
       });
     },
 
-    staffbotTask: function staffbotTask(task) {
-      return $http.post(getApiUrl('staffbot_task'), {
+    staffTask: function staffTask(task) {
+      return $http.post(getApiUrl('staff_task'), {
         'task_id': task.id
       });
     },
@@ -58078,7 +58078,7 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
         'class': 'btn btn-default btn-xs pull-right'
       }).text('Staffbot').on('click', function (assignmentKey) {
         var assignment = dataService.assignmentFromKey(assignmentKey);
-        assignmentsVis.staffbotTask(assignment.task, d3.select(this));
+        assignmentsVis.staffTask(assignment.task, d3.select(this));
       });
     },
     assign_task: function assign_task(task, inputEl) {
@@ -58131,12 +58131,12 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
         assignment.reassigning = false;
       });
     },
-    staffbotTask: function staffbotTask(task, buttonEl) {
+    staffTask: function staffTask(task, buttonEl) {
       buttonEl.text('Sending request ...');
       orchestraApi.staffbotTask(task).then(function (response) {
-        buttonEl.text('Staffbot request sent');
+        buttonEl.text('StaffBot request sent');
       }, function (response) {
-        var errorMessage = 'Error creating a staffbot request.';
+        var errorMessage = 'Error creating a StaffBot request.';
         if (response.status === 400) {
           errorMessage = response.data.message;
         }

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -58079,10 +58079,7 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
         return assignment.task.is_human && assignment.task.status !== 'Complete';
       }).append('button').attr({
         'class': 'btn btn-default btn-xs pull-right'
-      }).text(function (data) {
-        var assignment = dataService.assignmentFromKey(data);
-        return assignment.worker.id ? 'Restaff' : 'Staff';
-      }).on('click', function (assignmentKey) {
+      }).text(assignmentsVis.getStaffButtonLabel).on('click', function (assignmentKey) {
         var assignment = dataService.assignmentFromKey(assignmentKey);
         assignmentsVis.staffTask(assignment.task, d3.select(this));
       });
@@ -58137,17 +58134,19 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
         assignment.reassigning = false;
       });
     },
+    getStaffButtonLabel: function getStaffButtonLabel(data) {
+      var assignment = dataService.assignmentFromKey(data);
+      return assignment.worker.id ? 'Restaff' : 'Staff';
+    },
     staffTask: function staffTask(task, buttonEl) {
       buttonEl.text('Sending request ...');
-      orchestraApi.staffbotTask(task).then(function (response) {
+      orchestraApi.staffTask(task).then(function () {
         buttonEl.text('StaffBot request sent');
-      }, function (response) {
+      }, function () {
         var errorMessage = 'Error creating a StaffBot request.';
-        if (response.status === 400) {
-          errorMessage = response.data.message;
-        }
         window.alert(errorMessage);
-      });
+        buttonEl.text(this.getStaffButtonLabel);
+      }.bind(this));
     }
   };
 }

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -42517,7 +42517,6 @@ function orchestraApi($http) {
     },
 
     staffbotTask: function staffbotTask(task) {
-      console.log('staffbotTask');
       return $http.post(getApiUrl('staffbot_task'), {
         'task_id': task.id
       });
@@ -58079,7 +58078,7 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
         'class': 'btn btn-default btn-xs pull-right'
       }).text('Staffbot').on('click', function (assignmentKey) {
         var assignment = dataService.assignmentFromKey(assignmentKey);
-        assignmentsVis.staffbotTask(assignment.task);
+        assignmentsVis.staffbotTask(assignment.task, d3.select(this));
       });
     },
     assign_task: function assign_task(task, inputEl) {
@@ -58132,8 +58131,17 @@ function assignmentsVis(dataService, orchestraApi, iterationsVis, visUtils) {
         assignment.reassigning = false;
       });
     },
-    staffbotTask: function staffbotTask(task) {
-      orchestraApi.staffbotTask(task);
+    staffbotTask: function staffbotTask(task, buttonEl) {
+      buttonEl.text('Sending request ...');
+      orchestraApi.staffbotTask(task).then(function (response) {
+        buttonEl.text('Staffbot request sent');
+      }, function (response) {
+        var errorMessage = 'Error creating a staffbot request.';
+        if (response.status === 400) {
+          errorMessage = response.data.message;
+        }
+        window.alert(errorMessage);
+      });
     }
   };
 }

--- a/orchestra/static/orchestra/common/js/orchestra_api.es6.js
+++ b/orchestra/static/orchestra/common/js/orchestra_api.es6.js
@@ -37,7 +37,6 @@ export default function orchestraApi ($http) {
     },
 
     staffbotTask: function (task) {
-      console.log('staffbotTask')
       return $http.post(getApiUrl('staffbot_task'), {
         'task_id': task.id
       })

--- a/orchestra/static/orchestra/common/js/orchestra_api.es6.js
+++ b/orchestra/static/orchestra/common/js/orchestra_api.es6.js
@@ -36,6 +36,13 @@ export default function orchestraApi ($http) {
       })
     },
 
+    staffbotTask: function (task) {
+      console.log('staffbotTask')
+      return $http.post(getApiUrl('staffbot_task'), {
+        'task_id': task.id
+      })
+    },
+
     revertTask: function (taskId, iterationId, revertBefore, commit) {
       return $http.post(getApiUrl('revert_task'), {
         'task_id': taskId,

--- a/orchestra/static/orchestra/common/js/orchestra_api.es6.js
+++ b/orchestra/static/orchestra/common/js/orchestra_api.es6.js
@@ -36,8 +36,8 @@ export default function orchestraApi ($http) {
       })
     },
 
-    staffbotTask: function (task) {
-      return $http.post(getApiUrl('staffbot_task'), {
+    staffTask: function (task) {
+      return $http.post(getApiUrl('staff_task'), {
         'task_id': task.id
       })
     },

--- a/orchestra/static/orchestra/project-management/assignments-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/assignments-vis.es6.js
@@ -179,7 +179,7 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
       buttonEl.text('Sending request ...')
       orchestraApi.staffbotTask(task)
         .then(function (response) {
-          buttonEl.text('Staffbot request sent')
+          buttonEl.text('StaffBot request sent')
         }, function (response) {
           var errorMessage = 'Error creating a StaffBot request.'
           if (response.status === 400) {

--- a/orchestra/static/orchestra/project-management/assignments-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/assignments-vis.es6.js
@@ -115,7 +115,10 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
         .attr({
           'class': 'btn btn-default btn-xs pull-right'
         })
-        .text('Staffbot')
+        .text(function (data) {
+          var assignment = dataService.assignmentFromKey(data)
+          return assignment.worker.id ? 'Restaff' : 'Staff'
+        })
         .on('click', function (assignmentKey) {
           var assignment = dataService.assignmentFromKey(assignmentKey)
           assignmentsVis.staffTask(assignment.task, d3.select(this))

--- a/orchestra/static/orchestra/project-management/assignments-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/assignments-vis.es6.js
@@ -181,7 +181,7 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
         .then(function (response) {
           buttonEl.text('Staffbot request sent')
         }, function (response) {
-          var errorMessage = 'Error creating a staffbot request.'
+          var errorMessage = 'Error creating a StaffBot request.'
           if (response.status === 400) {
             errorMessage = response.data.message
           }

--- a/orchestra/static/orchestra/project-management/assignments-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/assignments-vis.es6.js
@@ -118,10 +118,7 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
         .attr({
           'class': 'btn btn-default btn-xs pull-right'
         })
-        .text(function (data) {
-          var assignment = dataService.assignmentFromKey(data)
-          return assignment.worker.id ? 'Restaff' : 'Staff'
-        })
+        .text(assignmentsVis.getStaffButtonLabel)
         .on('click', function (assignmentKey) {
           var assignment = dataService.assignmentFromKey(assignmentKey)
           assignmentsVis.staffTask(assignment.task, d3.select(this))
@@ -181,18 +178,21 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
           assignment.reassigning = false
         })
     },
+    getStaffButtonLabel: function (data) {
+      var assignment = dataService.assignmentFromKey(data)
+      return assignment.worker.id ? 'Restaff' : 'Staff'
+    },
     staffTask: function (task, buttonEl) {
       buttonEl.text('Sending request ...')
-      orchestraApi.staffbotTask(task)
-        .then(function (response) {
+      orchestraApi.staffTask(task)
+        .then(function () {
           buttonEl.text('StaffBot request sent')
-        }, function (response) {
+        }, function () {
           var errorMessage = 'Error creating a StaffBot request.'
-          if (response.status === 400) {
-            errorMessage = response.data.message
-          }
           window.alert(errorMessage)
-        })
+          buttonEl.text(this.getStaffButtonLabel)
+        }.bind(this)
+      )
     }
   }
 }

--- a/orchestra/static/orchestra/project-management/assignments-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/assignments-vis.es6.js
@@ -118,7 +118,7 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
         .text('Staffbot')
         .on('click', function (assignmentKey) {
           var assignment = dataService.assignmentFromKey(assignmentKey)
-          assignmentsVis.staffbotTask(assignment.task)
+          assignmentsVis.staffbotTask(assignment.task, d3.select(this))
         })
     },
     assign_task: function (task, inputEl) {
@@ -175,8 +175,18 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
           assignment.reassigning = false
         })
     },
-    staffbotTask: function (task) {
+    staffbotTask: function (task, buttonEl) {
+      buttonEl.text('Sending request ...')
       orchestraApi.staffbotTask(task)
+        .then(function (response) {
+          buttonEl.text('Staffbot request sent')
+        }, function (response) {
+          var errorMessage = 'Error creating a staffbot request.'
+          if (response.status === 400) {
+            errorMessage = response.data.message
+          }
+          window.alert(errorMessage)
+        })
     }
   }
 }

--- a/orchestra/static/orchestra/project-management/assignments-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/assignments-vis.es6.js
@@ -116,8 +116,9 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
           'class': 'btn btn-default btn-xs pull-right'
         })
         .text('Staffbot')
-        .on('click', function () {
-          window.alert('staffbot!')
+        .on('click', function (assignmentKey) {
+          var assignment = dataService.assignmentFromKey(assignmentKey)
+          assignmentsVis.staffbotTask(assignment.task)
         })
     },
     assign_task: function (task, inputEl) {
@@ -173,6 +174,9 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
           inputEl.node().value = assignment.worker.username
           assignment.reassigning = false
         })
+    },
+    staffbotTask: function (task) {
+      orchestraApi.staffbotTask(task)
     }
   }
 }

--- a/orchestra/static/orchestra/project-management/assignments-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/assignments-vis.es6.js
@@ -110,6 +110,15 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
           var assignment = dataService.assignmentFromKey(assignmentKey)
           this.value = assignment.task.is_human ? assignment.worker.username : 'Machine'
         })
+
+      assignmentsMetaEnter.append('button')
+        .attr({
+          'class': 'btn btn-default btn-xs pull-right'
+        })
+        .text('Staffbot')
+        .on('click', function () {
+          window.alert('staffbot!')
+        })
     },
     assign_task: function (task, inputEl) {
       /**

--- a/orchestra/static/orchestra/project-management/assignments-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/assignments-vis.es6.js
@@ -111,7 +111,10 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
           this.value = assignment.task.is_human ? assignment.worker.username : 'Machine'
         })
 
-      assignmentsMetaEnter.append('button')
+      assignmentsMetaEnter.filter(function (data) {
+        var assignment = dataService.assignmentFromKey(data)
+        return assignment.task.is_human && assignment.task.status !== 'Complete'
+      }).append('button')
         .attr({
           'class': 'btn btn-default btn-xs pull-right'
         })

--- a/orchestra/static/orchestra/project-management/assignments-vis.es6.js
+++ b/orchestra/static/orchestra/project-management/assignments-vis.es6.js
@@ -118,7 +118,7 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
         .text('Staffbot')
         .on('click', function (assignmentKey) {
           var assignment = dataService.assignmentFromKey(assignmentKey)
-          assignmentsVis.staffbotTask(assignment.task, d3.select(this))
+          assignmentsVis.staffTask(assignment.task, d3.select(this))
         })
     },
     assign_task: function (task, inputEl) {
@@ -175,7 +175,7 @@ export default function assignmentsVis (dataService, orchestraApi, iterationsVis
           assignment.reassigning = false
         })
     },
-    staffbotTask: function (task, buttonEl) {
+    staffTask: function (task, buttonEl) {
       buttonEl.text('Sending request ...')
       orchestraApi.staffbotTask(task)
         .then(function (response) {


### PR DESCRIPTION
This change adds a staffbot button to tasks on the project management page. 

If there is no task assignment, clicking the staffbot button will create a StaffbotRequest for that task. If there is an existing task assignment, it will restaff the task. 

This functionality makes it more convenient to use staffbot to recruit workers for a task that doesn't have automatic assignment mechanism.

![image](https://user-images.githubusercontent.com/3648911/73820638-c509d580-4824-11ea-9bb5-51e7a6afff97.png)
