### PR TITLE
[WIP] Allow the open source orchestra to be injected with closed source components

### DIFF
--- a/docs/source/frontend.rst
+++ b/docs/source/frontend.rst
@@ -1,0 +1,49 @@
+########
+Frontend
+########
+
+Below, we'll walk through the frontend portion of the codebase written in 
+React.
+
+***********
+Compilation
+***********
+
+The frontend codebase uses the create-react-app starter as the base, so as to 
+ease the configuration process. As of current, we use an add-on called 
+``customize-cra`` to customize some of the webpack features that we need, so that
+we don't have to 'eject' from create-react-app just to use those functionality.
+
+Features that we use as of current:
+- ``babelInclude`` - this is to include compilation of our open-source design 
+system, as we do not precompile the design system before releasing an npm 
+package.
+- ``addWebpackExternals`` - this allows us to exclude certain packages from the 
+webpack compilation. Right now, we are excluding React, ReactDOM, and ReactRedux
+as these packages are depended on for both the closed source portion of the
+code. 
+
+******************************
+Closed-source Code Compilation
+******************************
+
+We integrate Orchestra with our closed-source product, and we had to figure out
+a way to inject closed source components in the open source world. Here are some
+advice on how you can implement this feature.
+
+The closed source portion of the codebase would be compiled, and the compiled 
+scripts would be included in the open source portion of the codebase. We include
+these scripts programmatically, by injecting the script tags into the compiled
+``index.html`` You can customize which scripts to be injected by modifying the 
+``orchestra/settings.py`` file. 
+
+We run these urls through a ``static`` template tag function to link the closed
+source assets up. Through the views.py, we inject these scripts into the 
+``index.html``.
+
+As for using the closed source component in the open sourced codebase, we inject
+the components in the ``window.orchestra`` global object in the closed source
+portion, and we refer to the relevant components that we want to use through the
+global object. These closed source components would have access to the Redux
+state since the objects are nested in the DOM with the Redux provider, and hence
+selectors and dispatches can be used easily.

--- a/orchestra/frontend/config-overrides.js
+++ b/orchestra/frontend/config-overrides.js
@@ -13,6 +13,6 @@ module.exports = override(
     react: 'React',
     'react-dom': 'ReactDOM',
     'react-redux': 'ReactRedux'
-  })
+  }),
 )
 

--- a/orchestra/frontend/config-overrides.js
+++ b/orchestra/frontend/config-overrides.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { override, babelInclude } = require('customize-cra');
+const { override, babelInclude, addWebpackExternals } = require('customize-cra');
 
 module.exports = override(
   babelInclude([
@@ -8,6 +8,11 @@ module.exports = override(
     // the metronome design system has not been compiled before exporting.
     path.resolve('node_modules/@b12/metronome'),
     path.resolve('src/')
-  ])
+  ]),
+  addWebpackExternals({
+    react: 'React',
+    'react-dom': 'ReactDOM',
+    'react-redux': 'ReactRedux'
+  })
 )
 

--- a/orchestra/frontend/package.json
+++ b/orchestra/frontend/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@b12/metronome": "^1.0.0",
-    "@loadable/component": "5.12.0",
     "@reduxjs/toolkit": "1.3.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/orchestra/frontend/package.json
+++ b/orchestra/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@b12/metronome": "^1.0.0",
+    "@loadable/component": "5.12.0",
     "@reduxjs/toolkit": "1.3.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/orchestra/frontend/public/index.html
+++ b/orchestra/frontend/public/index.html
@@ -33,6 +33,10 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+  <!-- 
+    TODO(elstonayx): Figure out a way to dynamically load UMD React/ReactRedux packages
+    so that we don't have to manually update it through the script tags.
+   -->
   <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-redux@7.2.0/dist/react-redux.js" crossorigin></script>

--- a/orchestra/frontend/public/index.html
+++ b/orchestra/frontend/public/index.html
@@ -33,6 +33,9 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+  <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-redux@7.2.0/dist/react-redux.js" crossorigin></script>
   {% for js in javascript_includes %}
   {{ js | safe }}
   {% endfor %}

--- a/orchestra/frontend/public/index.html
+++ b/orchestra/frontend/public/index.html
@@ -1,15 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="An open-source Robotic Process Automation system to orchestrate teams of experts and machines"
-    />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description"
+    content="An open-source Robotic Process Automation system to orchestrate teams of experts and machines" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -18,12 +17,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Orchestra</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>Orchestra</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -33,5 +33,9 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+  {% for js in javascript_includes %}
+  {{ js | safe }}
+  {% endfor %}
+</body>
+
 </html>

--- a/orchestra/frontend/src/assets/ShuffleIcon.tsx
+++ b/orchestra/frontend/src/assets/ShuffleIcon.tsx
@@ -1,22 +1,22 @@
-import React from 'react';
+import React from 'react'
 
 const ShuffleIcon = () => {
   return (
     <svg width="24px" height="18px" viewBox="0 0 24 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
       <g id="Dashboard-–-Tabular" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-          <g transform="translate(-30.000000, -25.000000)" fill="#695FF6" fill-rule="nonzero" id="Header">
-              <g>
-                  <g id="Group">
-                      <g transform="translate(30.000000, 23.000000)">
-                          <g id="shuffle-98" transform="translate(0.000000, 2.000000)">
-                              <path d="M0,5 L4.219,5 C5.069,5 5.881,5.362 6.448,5.993 L7.809,7.505 L9.154,6.01 L7.934,4.654 C6.989,3.604 5.635,3 4.219,3 L0,3 L0,5 Z" id="Path"></path>
-                              <path d="M24,4 L19,0 L19,3 L16.781,3 C15.365,3 14.01,3.604 13.065,4.655 L6.448,12.007 C5.881,12.638 5.068,13 4.219,13 L0,13 L0,15 L4.219,15 C5.635,15 6.99,14.396 7.935,13.345 L14.552,5.993 C15.119,5.362 15.932,5 16.781,5 L19,5 L19,8 L24,4 Z" id="Path"></path>
-                              <path d="M24,14 L19,10 L19,13 L16.781,13 C15.931,13 15.119,12.638 14.552,12.007 L13.191,10.495 L11.846,11.99 L13.066,13.345 C14.011,14.397 15.366,15 16.782,15 L19,15 L19,18 L24,14 Z" id="Path"></path>
-                          </g>
-                      </g>
-                  </g>
+        <g transform="translate(-30.000000, -25.000000)" fill="#695FF6" fillRule="nonzero" id="Header">
+          <g>
+            <g id="Group">
+              <g transform="translate(30.000000, 23.000000)">
+                <g id="shuffle-98" transform="translate(0.000000, 2.000000)">
+                  <path d="M0,5 L4.219,5 C5.069,5 5.881,5.362 6.448,5.993 L7.809,7.505 L9.154,6.01 L7.934,4.654 C6.989,3.604 5.635,3 4.219,3 L0,3 L0,5 Z" id="Path"></path>
+                  <path d="M24,4 L19,0 L19,3 L16.781,3 C15.365,3 14.01,3.604 13.065,4.655 L6.448,12.007 C5.881,12.638 5.068,13 4.219,13 L0,13 L0,15 L4.219,15 C5.635,15 6.99,14.396 7.935,13.345 L14.552,5.993 C15.119,5.362 15.932,5 16.781,5 L19,5 L19,8 L24,4 Z" id="Path"></path>
+                  <path d="M24,14 L19,10 L19,13 L16.781,13 C15.931,13 15.119,12.638 14.552,12.007 L13.191,10.495 L11.846,11.99 L13.066,13.345 C14.011,14.397 15.366,15 16.782,15 L19,15 L19,18 L24,14 Z" id="Path"></path>
+                </g>
               </g>
+            </g>
           </g>
+        </g>
       </g>
     </svg>
   )

--- a/orchestra/frontend/src/global.d.ts
+++ b/orchestra/frontend/src/global.d.ts
@@ -1,0 +1,6 @@
+interface Window {
+  orchestra?: {
+    tasks: React.FC<{ id: string }>;
+  };
+}
+

--- a/orchestra/frontend/src/views/task/Task.tsx
+++ b/orchestra/frontend/src/views/task/Task.tsx
@@ -6,7 +6,7 @@ const Task = () => {
   const LoadableTaskComponent = window.orchestra?.tasks
   return (
     <div>
-      {LoadableTaskComponent && <LoadableTaskComponent />}
+      <LoadableTaskComponent />
     </div>
   )
 }

--- a/orchestra/frontend/src/views/task/Task.tsx
+++ b/orchestra/frontend/src/views/task/Task.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
-import {
-  useParams
-} from 'react-router-dom'
+import { useParams } from 'react-router-dom'
+import store from '../../state/store'
+
+window.ReactOrchestra = require('react')
 
 const Task = () => {
-  const { taskId } = useParams();
+  const { taskId } = useParams()
+  const LoadableTaskComponent = window.orchestra?.task
   return (
-        <div>
-          Task view: { taskId }
-        </div>
-    )
+    <div>
+      {LoadableTaskComponent && <LoadableTaskComponent store={store} />}
+    </div>
+  )
 }
 
-export default Task;
+export default Task

--- a/orchestra/frontend/src/views/task/Task.tsx
+++ b/orchestra/frontend/src/views/task/Task.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
-import store from '../../state/store'
-
-window.ReactOrchestra = require('react')
 
 const Task = () => {
   const { taskId } = useParams()
-  const LoadableTaskComponent = window.orchestra?.task
+  const LoadableTaskComponent = window.orchestra?.tasks
   return (
     <div>
-      {LoadableTaskComponent && <LoadableTaskComponent store={store} />}
+      {LoadableTaskComponent && <LoadableTaskComponent />}
     </div>
   )
 }

--- a/orchestra/frontend/yarn.lock
+++ b/orchestra/frontend/yarn.lock
@@ -930,6 +930,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.7":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
+  integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
@@ -1170,6 +1177,14 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@loadable/component@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.12.0.tgz#34d056d15f53dc08d04e9203cad6867cf4f7306c"
+  integrity sha512-eDG7FPZ8tCFA/mqu2IrYV6eS+UxGBo21PwtEV9QpkpYrx25xKRXzJUm36yfQPK3o7jXu43xpPkwiU4mLWcjJlw==
+  dependencies:
+    "@babel/runtime" "^7.7.7"
+    hoist-non-react-statics "^3.3.1"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -5429,7 +5444,7 @@ hoist-non-react-statics@^2.2.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==

--- a/orchestra/settings.py
+++ b/orchestra/settings.py
@@ -1,0 +1,5 @@
+ORCHESTRA_JS_INCLUDES = [
+    '/main/main.js',
+    '/vendor/vendor.js',
+    '/common/common.js'
+]

--- a/orchestra/views.py
+++ b/orchestra/views.py
@@ -46,6 +46,8 @@ from orchestra.utils.task_lifecycle import worker_assigned_to_rejected_task
 from orchestra.utils.task_lifecycle import worker_has_reviewer_status
 from orchestra.utils.view_helpers import IsAssociatedWorker
 
+from orchestra.settings import ORCHESTRA_JS_INCLUDES
+
 logger = logging.getLogger(__name__)
 UserModel = get_user_model()
 
@@ -99,7 +101,11 @@ def index(request):
 
 @login_required
 def newindex(request):
-    return render(request, 'orchestra/newindex.html')
+    return render(request, 'orchestra/newindex.html', {
+        'javascript_includes': [
+            _get_script_tag(static(file)) for file in ORCHESTRA_JS_INCLUDES
+        ]
+    })
 
 
 @json_view


### PR DESCRIPTION
This PR extends the functionality of the new Orchestra frontend to allow closed source components to be injected in the respective places, and to use a singular source of React and ReactRedux packages so that both the open source and the closed source can share the same package.