### PR TITLE
Allows re-loading a workflow version with --force if it has new steps.

### DIFF
--- a/orchestra/tests/helpers/workflow.py
+++ b/orchestra/tests/helpers/workflow.py
@@ -876,11 +876,12 @@ def assert_test_dir_v1_loaded(test_case, extra_step=False):
                     ],
                 },
             })
-        test_case.assertEqual(set(step4.required_certifications.all()),
-                              set(Certification.objects.filter(
-                                  slug__in=['certification1', 'certification2'],
-                                  workflow__slug='test_dir',
-                              )))
+        test_case.assertEqual(
+            set(step4.required_certifications.all()),
+            set(Certification.objects.filter(
+                slug__in=['certification1', 'certification2'],
+                workflow__slug='test_dir',
+            )))
         test_case.assertEqual(list(step4.creation_depends_on.all()), [step1])
         test_case.assertEqual(list(step4.submission_depends_on.all()), [step2])
 

--- a/orchestra/tests/helpers/workflow.py
+++ b/orchestra/tests/helpers/workflow.py
@@ -743,7 +743,7 @@ def assert_test_dir_v1_not_loaded(test_case):
     })
 
 
-def assert_test_dir_v1_loaded(test_case):
+def assert_test_dir_v1_loaded(test_case, extra_step=False):
     """ Verify that the test_dir workflow v1's DB objects exist. """
     version1 = test_case.assertModelInstanceExists(
         WorkflowVersion,
@@ -848,6 +848,41 @@ def assert_test_dir_v1_loaded(test_case):
                           )))
     test_case.assertEqual(list(step3.creation_depends_on.all()), [step1])
     test_case.assertEqual(list(step3.submission_depends_on.all()), [step2])
+
+    if extra_step:
+        step4 = test_case.assertModelInstanceExists(
+            Step,
+            {
+                'workflow_version': version1,
+                'slug': 's4',
+            },
+            {
+                'name': 'Step 4',
+                'description': 'The fourth step',
+                'is_human': True,
+                'execution_function': {},
+                'review_policy': {
+                    'policy': 'sampled_review',
+                    'rate': 1,
+                    'max_reviews': 1,
+                },
+                'user_interface': {
+                    'angular_module': 'test_dir.v1.s3',
+                    'angular_directive': 's3',
+                    'javascript_includes': [
+                        'test_dir/v1/s3/js/modules.js',
+                        'test_dir/v1/s3/js/controllers.js',
+                        'test_dir/v1/s3/js/directives.js',
+                    ],
+                },
+            })
+        test_case.assertEqual(set(step4.required_certifications.all()),
+                              set(Certification.objects.filter(
+                                  slug__in=['certification1', 'certification2'],
+                                  workflow__slug='test_dir',
+                              )))
+        test_case.assertEqual(list(step4.creation_depends_on.all()), [step1])
+        test_case.assertEqual(list(step4.submission_depends_on.all()), [step2])
 
 
 def assert_test_dir_v2_not_loaded(test_case):

--- a/orchestra/workflow/load.py
+++ b/orchestra/workflow/load.py
@@ -128,11 +128,11 @@ def load_workflow_version(version_data, workflow, force=False):
             .filter(workflow_version=version)
             .values_list('slug', flat=True)
         )
-        if new_step_slugs != old_step_slugs:
-            raise WorkflowError('Even with --force, you cannot change the '
-                                'steps of a workflow. Drop and recreate the '
-                                'database to reset, or create a new version '
-                                'for your workflow.')
+        if old_step_slugs - new_step_slugs:
+            raise WorkflowError(
+                'Even with --force, you cannot remove steps from a workflow.'
+                'Drop and recreate the database to reset, or create a new '
+                'version for your workflow.')
 
     # Create or update the version steps.
     old_creation_dependencies = {}


### PR DESCRIPTION
This PR makes it possible to add steps to the leaves of a workflow by re-loading it with the `--force` option.
* Previously, any difference in steps between the old and new versions would result in an error.
* This PR still prevents removing steps from the old version, or inserting steps before other steps, as that could break existing projects.
* The logic for why this change is safe is as follows:
   * Since adding a new step doesn't change the `created_depends_on` or `submission_depends_on` properties of any other step, existing projects can't be prevented from proceeding.
   * Since new steps can't be inserted into the topology as antecedents of another step, existing projects can't be prevented from completing.
   * For existing projects, calling `create_subsequent_tasks()` after adding Steps to the workflow might result in new tasks being created, but they won't be created by default upon loading the new steps.