### PR TITLE
Speed up todo lists loading time on task page

### DIFF
--- a/orchestra/static/dist/main.css
+++ b/orchestra/static/dist/main.css
@@ -25,7 +25,7 @@
  * This partial provides common variables and mixins useful for various view and
  * component styles.
  */
-.disable-select, .checklist-wrapper .toggle-completed, li.checklist-item .line-item .item-title input[type="text"].readonly, .new-item .line-item .item-title input[type="text"].readonly, li.checklist-item .item-tools, .new-item .item-tools {
+.disable-select, .checklist-wrapper .toggle-completed, li.checklist-item .line-item .item-title input.readonly[type="text"], .new-item .line-item .item-title input.readonly[type="text"], li.checklist-item .item-tools, .new-item .item-tools {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -khtml-user-select: none;
@@ -1919,7 +1919,7 @@ a.logo {
 @charset "UTF-8";
 /*!
  * Pikaday
- * Copyright © 2014 David Bushell | BSD & MIT license | http://dbushell.com/
+ * Copyright © 2014 David Bushell | BSD & MIT license | https://dbushell.com/
  */
 .pika-single {
   z-index: 9999;
@@ -2065,15 +2065,19 @@ a.logo {
     border-radius: 3px; }
   .is-disabled .pika-button,
   .is-outside-current-month .pika-button {
-    pointer-events: none;
-    cursor: default;
     color: #999;
     opacity: .3; }
+  .is-disabled .pika-button {
+    pointer-events: none;
+    cursor: default; }
   .pika-button:hover {
     color: #fff;
     background: #ff8000;
     box-shadow: none;
     border-radius: 3px; }
+  .pika-button .is-selection-disabled {
+    pointer-events: none;
+    cursor: default; }
 
 .pika-week {
   font-size: 11px;

--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -66554,6 +66554,9 @@ exports.default = name;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
 exports.default = todoList;
 
 var _lodash = __webpack_require__(4);
@@ -66727,10 +66730,15 @@ function todoList(orchestraApi) {
         var p1 = todoListTemplateApi.list();
         var p2 = todoQaApi.workerTaskRecentTodoQas(todoList.taskId);
         var p3 = todoApi.list(todoList.projectId);
-        Promise.all([p1, p2, p3]).then(function (values) {
-          todoList.templates = values[0];
-          todoList.todoQas = values[1];
-          todoList.todos = todoList.transformToTree(values[2]);
+        Promise.all([p1, p2, p3]).then(function (_ref) {
+          var _ref2 = _slicedToArray(_ref, 3),
+              templates = _ref2[0],
+              todoQas = _ref2[1],
+              todos = _ref2[2];
+
+          todoList.templates = templates;
+          todoList.todoQas = todoQas;
+          todoList.todos = todoList.transformToTree(todos);
           todoList.ready = true;
         });
       });

--- a/orchestra/static/orchestra/todos/todo-list.directive.es6.js
+++ b/orchestra/static/orchestra/todos/todo-list.directive.es6.js
@@ -154,16 +154,14 @@ export default function todoList (orchestraApi) {
             }, {})
           todoList.possibleTasks = Object.values(tasks).filter(task => task.status !== 'Complete' && humanSteps.has(task.step_slug))
 
-          // TODO(marcua): parallelize requests rather than chaining `then`s.
-          todoApi.list(todoList.projectId).then((todos) => {
-            todoListTemplateApi.list().then((templates) => {
-              todoQaApi.workerTaskRecentTodoQas(todoList.taskId).then((todoQas) => {
-                todoList.todoQas = todoQas
-                todoList.templates = templates
-                todoList.todos = todoList.transformToTree(todos)
-                todoList.ready = true
-              })
-            })
+          const p1 = todoListTemplateApi.list()
+          const p2 = todoQaApi.workerTaskRecentTodoQas(todoList.taskId)
+          const p3 = todoApi.list(todoList.projectId)
+          Promise.all([p1, p2, p3]).then((values) => {
+            todoList.todoQas = values[1]
+            todoList.templates = values[0]
+            todoList.todos = todoList.transformToTree(values[2])
+            todoList.ready = true
           })
         })
     }

--- a/orchestra/static/orchestra/todos/todo-list.directive.es6.js
+++ b/orchestra/static/orchestra/todos/todo-list.directive.es6.js
@@ -158,8 +158,8 @@ export default function todoList (orchestraApi) {
           const p2 = todoQaApi.workerTaskRecentTodoQas(todoList.taskId)
           const p3 = todoApi.list(todoList.projectId)
           Promise.all([p1, p2, p3]).then((values) => {
-            todoList.todoQas = values[1]
             todoList.templates = values[0]
+            todoList.todoQas = values[1]
             todoList.todos = todoList.transformToTree(values[2])
             todoList.ready = true
           })

--- a/orchestra/static/orchestra/todos/todo-list.directive.es6.js
+++ b/orchestra/static/orchestra/todos/todo-list.directive.es6.js
@@ -157,10 +157,10 @@ export default function todoList (orchestraApi) {
           const p1 = todoListTemplateApi.list()
           const p2 = todoQaApi.workerTaskRecentTodoQas(todoList.taskId)
           const p3 = todoApi.list(todoList.projectId)
-          Promise.all([p1, p2, p3]).then((values) => {
-            todoList.templates = values[0]
-            todoList.todoQas = values[1]
-            todoList.todos = todoList.transformToTree(values[2])
+          Promise.all([p1, p2, p3]).then(([templates, todoQas, todos]) => {
+            todoList.templates = templates
+            todoList.todoQas = todoQas
+            todoList.todos = todoList.transformToTree(todos)
             todoList.ready = true
           })
         })

--- a/orchestra/static/orchestra/todos/todos.service.es6.js
+++ b/orchestra/static/orchestra/todos/todos.service.es6.js
@@ -13,7 +13,7 @@ export default function todoApi ($http) {
   return {
     create: (todo) => $http.post(listCreate(), todo)
       .then(response => response.data),
-    list: (projectId) => $http.get(listCreate(projectId))
+    list: (projectId) => $http.get(listCreate(projectId), {cache: true})
       .then(response => response.data),
     update: (todo) => $http.put(details(todo.id), todo),
     delete: (todo) => $http.delete(details(todo.id))

--- a/orchestra/todos/views.py
+++ b/orchestra/todos/views.py
@@ -136,7 +136,7 @@ class GenericTodoViewset(ModelViewSet):
     serializer_class = BulkTodoSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('project', 'step__slug',)
-    queryset = Todo.objects.all()
+    queryset = Todo.objects.select_related('step', 'qa').all()
 
     def get_serializer(self, *args, **kwargs):
         if isinstance(kwargs.get('data', {}), list):


### PR DESCRIPTION
The PR implements three optimizations:

1. Reduce the number of SQL queries triggered by the api request

> The todo lists were taking a lot of time to load because of extra SQL queries for loading related field `step` and additional `qa` data in `Todo` model. To fix this problem, I have prefetched related field step and qa information. 
> 
> Prior to this PR, an example query was taking around ~14 seconds and triggered ~800 SQL queries.
> 
> After this fix. the same query is now taking ~1 sec and 8 SQL queries.

2. Avoid duplicate api requests to todos endpoint. Reference link: https://docs.angularjs.org/api/ng/service/$http#caching

3. Parallelize api requests on client side using `Promise.all`
