### PR TITLE
Fix todolists and order steps on the project management page in the order in which they were created

### DIFF
--- a/orchestra/static/dist/main.js
+++ b/orchestra/static/dist/main.js
@@ -66740,6 +66740,7 @@ function todoList(orchestraApi) {
           todoList.todoQas = todoQas;
           todoList.todos = todoList.transformToTree(todos);
           todoList.ready = true;
+          $scope.$apply();
         });
       });
     }

--- a/orchestra/static/orchestra/todos/todo-list.directive.es6.js
+++ b/orchestra/static/orchestra/todos/todo-list.directive.es6.js
@@ -162,6 +162,7 @@ export default function todoList (orchestraApi) {
             todoList.todoQas = todoQas
             todoList.todos = todoList.transformToTree(todos)
             todoList.ready = true
+            $scope.$apply()
           })
         })
     }

--- a/orchestra/utils/task_lifecycle.py
+++ b/orchestra/utils/task_lifecycle.py
@@ -1198,7 +1198,7 @@ def create_subsequent_tasks(project):
             The modified project object.
     """
     workflow_version = project.workflow_version
-    all_steps = workflow_version.steps.all()
+    all_steps = workflow_version.steps.all().order_by('id')
 
     # get all completed tasks associated with a given project
     completed_tasks = Task.objects.filter(status=Task.Status.COMPLETE,


### PR DESCRIPTION
This PR implements two changes:
1. It fixes a bug in todolists: Todolists were not getting rendered after the promise.all got resolved on some occasions.

> This is happening because "Promise API is not integrated with the angular mechanism - meaning essentially that it doesn't trigger a digest cycle at key point of the lifecycle of the promises."
> 
> As a solution I added a $scope.$apply() at the end of the Promise.all() callback function to trigger a digest cycle manually.
> 
> Reference link: 
> https://stackoverflow.com/questions/41243148/angularjs-promise-all-not-updating-scope-while-q-all-does

2. It updates the order of steps on Project Management page by the order in which they were created