### PR TITLE
Updates hijack banner styles to be cleaner and collapsible.

### DIFF
--- a/orchestra/static/dist/orchestra/common/css/orchestra.css
+++ b/orchestra/static/dist/orchestra/common/css/orchestra.css
@@ -34,8 +34,11 @@
     line-height: 16px;
     text-align: left;
     font-weight: normal; }
-    .hijacked-warning__message span {
-      font-weight: bold; }
+    @media (max-width: 825px) {
+      .hijacked-warning__message {
+        font-size: 12px; }
+        .hijacked-warning__message .hidden-mobile {
+          display: none; } }
   .hijacked-warning__actions {
     display: flex;
     justify-content: flex-end; }
@@ -78,6 +81,11 @@
     padding: 4px 16px;
     cursor: pointer;
     border: 1px solid #ae9e49; }
+    @media (max-width: 825px) {
+      .hijacked-warning__button {
+        padding: 0 4px;
+        margin-left: 4px;
+        font-size: 12px; } }
     .hijacked-warning__button:hover {
       background: #fcfcfc; }
     .hijacked-warning__button:focus, .hijacked-warning__button:active {

--- a/orchestra/static/dist/orchestra/common/css/orchestra.css
+++ b/orchestra/static/dist/orchestra/common/css/orchestra.css
@@ -22,6 +22,89 @@
   to {
     transform: rotate(360deg); } }
 
+.hijacked-warning {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 50px;
+  padding: 5px 10px;
+  position: fixed; }
+  .hijacked-warning__message {
+    font-size: 14px;
+    line-height: 16px;
+    text-align: left;
+    font-weight: normal; }
+    .hijacked-warning__message span {
+      font-weight: bold; }
+  .hijacked-warning__actions {
+    display: flex;
+    justify-content: flex-end; }
+  .hijacked-warning__show {
+    display: none;
+    align-items: center;
+    background: #ae9e49;
+    position: absolute;
+    right: 10px;
+    top: 100%;
+    border-radius: 0 0 6px 6px;
+    padding: 3px 9px;
+    cursor: pointer; }
+    .hijacked-warning__show path {
+      fill: #000; }
+    .hijacked-warning__show span {
+      font-size: 11px;
+      line-height: 11px;
+      text-transform: uppercase;
+      font-weight: bold;
+      margin-left: 5px;
+      color: #000;
+      letter-spacing: 1px; }
+  .hijacked-warning__button {
+    margin: 0 0 0 10px;
+    box-sizing: border-box;
+    font-size: 14px;
+    line-height: 20px;
+    position: relative;
+    display: inline-block;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    user-select: none;
+    transition: all 0.1s ease-in-out;
+    text-decoration: none;
+    background: #ffffff;
+    border-radius: 3px;
+    color: #4d4d4d;
+    padding: 4px 16px;
+    cursor: pointer;
+    border: 1px solid #ae9e49; }
+    .hijacked-warning__button:hover {
+      background: #fcfcfc; }
+    .hijacked-warning__button:focus, .hijacked-warning__button:active {
+      border-color: #ae9e49;
+      box-shadow: inset 0px 0px 0px 1px #ae9e49;
+      outline: none;
+      text-decoration: none;
+      position: relative;
+      z-index: 10; }
+  .hijacked-warning ~ #container {
+    padding-top: 50px; }
+    .hijacked-warning ~ #container .header {
+      top: 50px; }
+    .hijacked-warning ~ #container .timecard-view {
+      top: 150px; }
+
+.hijack-message-hidden .hijacked-warning {
+  top: -44px; }
+  .hijack-message-hidden .hijacked-warning__show {
+    display: flex; }
+  .hijack-message-hidden .hijacked-warning ~ #container {
+    padding-top: 6px; }
+    .hijack-message-hidden .hijacked-warning ~ #container .header {
+      top: 6px; }
+    .hijack-message-hidden .hijacked-warning ~ #container .timecard-view {
+      top: 106px; }
+
 /**
  * Base stylesheet for Orchestra.
  *

--- a/orchestra/static/dist/orchestra/timing/timer/timer.css
+++ b/orchestra/static/dist/orchestra/timing/timer/timer.css
@@ -22,6 +22,89 @@
   to {
     transform: rotate(360deg); } }
 
+.hijacked-warning {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 50px;
+  padding: 5px 10px;
+  position: fixed; }
+  .hijacked-warning__message {
+    font-size: 14px;
+    line-height: 16px;
+    text-align: left;
+    font-weight: normal; }
+    .hijacked-warning__message span {
+      font-weight: bold; }
+  .hijacked-warning__actions {
+    display: flex;
+    justify-content: flex-end; }
+  .hijacked-warning__show {
+    display: none;
+    align-items: center;
+    background: #ae9e49;
+    position: absolute;
+    right: 10px;
+    top: 100%;
+    border-radius: 0 0 6px 6px;
+    padding: 3px 9px;
+    cursor: pointer; }
+    .hijacked-warning__show path {
+      fill: #000; }
+    .hijacked-warning__show span {
+      font-size: 11px;
+      line-height: 11px;
+      text-transform: uppercase;
+      font-weight: bold;
+      margin-left: 5px;
+      color: #000;
+      letter-spacing: 1px; }
+  .hijacked-warning__button {
+    margin: 0 0 0 10px;
+    box-sizing: border-box;
+    font-size: 14px;
+    line-height: 20px;
+    position: relative;
+    display: inline-block;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    user-select: none;
+    transition: all 0.1s ease-in-out;
+    text-decoration: none;
+    background: #ffffff;
+    border-radius: 3px;
+    color: #4d4d4d;
+    padding: 4px 16px;
+    cursor: pointer;
+    border: 1px solid #ae9e49; }
+    .hijacked-warning__button:hover {
+      background: #fcfcfc; }
+    .hijacked-warning__button:focus, .hijacked-warning__button:active {
+      border-color: #ae9e49;
+      box-shadow: inset 0px 0px 0px 1px #ae9e49;
+      outline: none;
+      text-decoration: none;
+      position: relative;
+      z-index: 10; }
+  .hijacked-warning ~ #container {
+    padding-top: 50px; }
+    .hijacked-warning ~ #container .header {
+      top: 50px; }
+    .hijacked-warning ~ #container .timecard-view {
+      top: 150px; }
+
+.hijack-message-hidden .hijacked-warning {
+  top: -44px; }
+  .hijack-message-hidden .hijacked-warning__show {
+    display: flex; }
+  .hijack-message-hidden .hijacked-warning ~ #container {
+    padding-top: 6px; }
+    .hijack-message-hidden .hijacked-warning ~ #container .header {
+      top: 6px; }
+    .hijack-message-hidden .hijacked-warning ~ #container .timecard-view {
+      top: 106px; }
+
 .timer {
   font-size: 18px; }
   .timer .popover-toggle {

--- a/orchestra/static/dist/orchestra/timing/timer/timer.css
+++ b/orchestra/static/dist/orchestra/timing/timer/timer.css
@@ -34,8 +34,11 @@
     line-height: 16px;
     text-align: left;
     font-weight: normal; }
-    .hijacked-warning__message span {
-      font-weight: bold; }
+    @media (max-width: 825px) {
+      .hijacked-warning__message {
+        font-size: 12px; }
+        .hijacked-warning__message .hidden-mobile {
+          display: none; } }
   .hijacked-warning__actions {
     display: flex;
     justify-content: flex-end; }
@@ -78,6 +81,11 @@
     padding: 4px 16px;
     cursor: pointer;
     border: 1px solid #ae9e49; }
+    @media (max-width: 825px) {
+      .hijacked-warning__button {
+        padding: 0 4px;
+        margin-left: 4px;
+        font-size: 12px; } }
     .hijacked-warning__button:hover {
       background: #fcfcfc; }
     .hijacked-warning__button:focus, .hijacked-warning__button:active {

--- a/orchestra/static/orchestra/common/css/_common.scss
+++ b/orchestra/static/orchestra/common/css/_common.scss
@@ -74,3 +74,124 @@ $main-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helveti
      transform:rotate(360deg);
   }
 }
+
+// styles related to the hijack banner
+.hijacked-warning {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 50px;
+  padding: 5px 10px;
+  position: fixed;
+
+  &__message {
+    font-size: 14px;
+    line-height: 16px;
+    text-align: left;
+    font-weight: normal;
+
+    span {
+      font-weight: bold;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  &__show {
+    display: none;
+    align-items: center;
+    background: #ae9e49;
+    position: absolute;
+    right: 10px;
+    top: 100%;
+    border-radius: 0 0 6px 6px;
+    padding: 3px 9px;
+    cursor: pointer;
+
+    path {
+      fill: #000;
+    }
+
+    span {
+      font-size: 11px;
+      line-height: 11px;
+      text-transform: uppercase;
+      font-weight: bold;
+      margin-left: 5px;
+      color: #000;
+      letter-spacing: 1px;
+    }
+  }
+
+  &__button {
+    margin: 0 0 0 10px;
+    box-sizing: border-box;
+    font-size: 14px;
+    line-height: 20px;
+    position: relative;
+    display: inline-block;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    user-select: none;
+    transition: all 0.1s ease-in-out;
+    text-decoration: none;
+    background: #ffffff;
+    border-radius: 3px;
+    color: #4d4d4d;
+    padding: 4px 16px;
+    cursor: pointer;
+    border: 1px solid #ae9e49;
+
+    &:hover {
+      background: #fcfcfc;
+    }
+
+    &:focus,
+    &:active {
+      border-color: #ae9e49;
+      box-shadow: inset 0px 0px 0px 1px #ae9e49;
+      outline: none;
+      text-decoration: none;
+      position: relative;
+      z-index: 10;
+    }
+  }
+
+  ~ #container {
+    padding-top: 50px;
+
+    .header {
+      top: 50px;
+    }
+
+    .timecard-view {
+      top: 150px;
+    }
+  }
+}
+
+.hijack-message-hidden {
+  .hijacked-warning {
+    top: -44px;
+
+    &__show {
+      display: flex;
+    }
+
+    ~ #container {
+      padding-top: 6px;
+
+      .header {
+        top: 6px;
+      }
+
+      .timecard-view {
+        top: 106px;
+      }
+    }
+  }
+}

--- a/orchestra/static/orchestra/common/css/_common.scss
+++ b/orchestra/static/orchestra/common/css/_common.scss
@@ -90,9 +90,13 @@ $main-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helveti
     text-align: left;
     font-weight: normal;
 
-    span {
-      font-weight: bold;
+    @media (max-width: 825px) {
+      font-size: 12px;
+      .hidden-mobile {
+        display: none;
+      }
     }
+
   }
 
   &__actions {
@@ -145,6 +149,12 @@ $main-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helveti
     padding: 4px 16px;
     cursor: pointer;
     border: 1px solid #ae9e49;
+
+    @media (max-width: 825px) {
+      padding: 0 4px;
+      margin-left: 4px;
+      font-size: 12px;
+    }
 
     &:hover {
       background: #fcfcfc;

--- a/orchestra/templates/hijack/notifications.html
+++ b/orchestra/templates/hijack/notifications.html
@@ -1,0 +1,38 @@
+{% load url from compat %}
+{% load i18n %}
+
+<div class="hijacked-warning hijacked-warning-default">
+  <div class="hijacked-warning__message">
+    {% blocktrans with user=request.user%}You are currently working on behalf of <span>{{ user }}</span>{% endblocktrans %}
+  </div>
+  <div class="hijacked-warning__actions">
+    <form action="{% url 'hijack:release_hijack' %}" method="POST">
+      {% csrf_token %}
+      <button class="hijacked-warning__button">{% blocktrans with user=request.user %}Release{% endblocktrans %}</button>
+    </form>
+    <form action="{% url 'hijack:disable_hijack_warning' %}?next={{ request.path }}" method="POST">
+      {% csrf_token %}
+      <button type="submit" class="hijacked-warning__button js-hijack-btn-hide">{% trans "Hide" %}</button>
+    </form>
+  </div>
+  <div class="hijacked-warning__show js-hijack-message-show">
+    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 256 256"><path d="M225.813 48.907L128 146.72 30.187 48.907 0 79.093l128 128 128-128z"/></svg>
+    <span>Show</span>
+  </div>
+</div>
+
+<script>
+  var btnElement = document.querySelector('.js-hijack-btn-hide')
+  var bodyElement = document.body
+  var hideElement = document.querySelector('.js-hijack-message-show')
+
+  btnElement.onclick = function(e) {
+    e.preventDefault()
+
+    bodyElement.classList.add('hijack-message-hidden')
+  }
+
+  hideElement.onclick = function(e) {
+    bodyElement.classList.remove('hijack-message-hidden')
+  }
+</script>

--- a/orchestra/templates/hijack/notifications.html
+++ b/orchestra/templates/hijack/notifications.html
@@ -3,17 +3,14 @@
 
 <div class="hijacked-warning hijacked-warning-default">
   <div class="hijacked-warning__message">
-    {% blocktrans with user=request.user%}You are currently working on behalf of <span>{{ user }}</span>{% endblocktrans %}
+    {% blocktrans with user=request.user%}<span class="hidden-mobile">You are currently working on behalf of</span><b> {{ user }}</b>{% endblocktrans %}
   </div>
   <div class="hijacked-warning__actions">
     <form action="{% url 'hijack:release_hijack' %}" method="POST">
       {% csrf_token %}
       <button class="hijacked-warning__button">{% blocktrans with user=request.user %}Release{% endblocktrans %}</button>
     </form>
-    <form action="{% url 'hijack:disable_hijack_warning' %}?next={{ request.path }}" method="POST">
-      {% csrf_token %}
-      <button type="submit" class="hijacked-warning__button js-hijack-btn-hide">{% trans "Hide" %}</button>
-    </form>
+    <button type="submit" class="hijacked-warning__button js-hijack-btn-hide">{% trans "Hide" %}</button>
   </div>
   <div class="hijacked-warning__show js-hijack-message-show">
     <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 256 256"><path d="M225.813 48.907L128 146.72 30.187 48.907 0 79.093l128 128 128-128z"/></svg>


### PR DESCRIPTION
Blast from the past! This PR applies nicer hijack styles to our hijack banner, so it can be hidden (now to a thin but visible line) without refreshing the page, and re-expanded easily.

Since 2020, I applied some tiny style updates to optimize for mobile. Here is the latest look:
| mobile | desktop |
|--------|---------|
| <img width="221" alt="Screen Shot 2023-04-06 at 2 36 13 PM" src="https://user-images.githubusercontent.com/390825/230465952-fb7100d9-305b-4cdd-8c33-37ed1744b807.png"> | <img width="1440" alt="Screen Shot 2023-04-06 at 2 35 50 PM" src="https://user-images.githubusercontent.com/390825/230465872-5f889432-7e95-4a11-966c-bd29b07e4c52.png"> |

