### PR TITLE
Fix update todos api latency

### DIFF
--- a/orchestra/todos/views.py
+++ b/orchestra/todos/views.py
@@ -149,7 +149,7 @@ class GenericTodoViewset(ModelViewSet):
 
     def get_queryset(self, ids=None):
         queryset = super().get_queryset()
-        if ids:
+        if ids is not None:
             queryset = queryset.filter(id__in=ids)
         return queryset.order_by('-created_at')
 


### PR DESCRIPTION
If we send an empty request to update todos API, our logic ` if ids` computed to false for `ids = []`. This led to a query to the entire Todo table and hence, slow API response. This PR fixes this by using an explicit `if ids is None` check.