### PR TITLE
Upgrade circle ci machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ jobs:
   build:
     working_directory: ~/orchestra
     docker:
-        - image: python:3.5.2
+        - image: python:3.5.6-stretch
     steps:
       - checkout
       - run:
           name: Install dependencies
           command: |
-            echo -e "deb http://deb.debian.org/debian jessie main\ndeb http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+            echo -e "deb http://deb.debian.org/debian stretch main\ndeb http://security.debian.org stretch/updates main" > /etc/apt/sources.list
             curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs
             curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
             export PATH="$HOME/.yarn/bin:$PATH"


### PR DESCRIPTION
Debian 8 (Jessie) has been EOL’d by Debian and so they changed the mirrors. More details are here: https://discuss.circleci.com/t/apt-get-update-failing-on-debian-8-jessie-based-convenience-images/29257

We change references from `jessie` to `stretch`.