### PR TITLE
Fix slack messages for todo updates and addition

### DIFF
--- a/orchestra/todos/views.py
+++ b/orchestra/todos/views.py
@@ -185,11 +185,10 @@ class GenericTodoViewset(ModelViewSet):
             old_data, QuerySet) else [old_data]
         data = serializer.save()
         todos = data if isinstance(data, list) else [data]
-        for idx, todo in enumerate(todos):
-            if isinstance(todo, Todo):
-                old_todo = old_todos[idx]
+        for old_todo, new_todo in zip(old_todos, todos):
+            if isinstance(new_todo, Todo):
                 notify_single_todo_update(
-                    self.request.user, old_todo, todo)
+                    self.request.user, old_todo, new_todo)
 
     def perform_create(self, serializer):
         data = serializer.save()

--- a/orchestra/todos/views.py
+++ b/orchestra/todos/views.py
@@ -15,7 +15,6 @@ from rest_framework.decorators import action
 from jsonview.exceptions import BadRequest
 from django.db.models.query import QuerySet
 
-
 from orchestra.core.errors import TodoListTemplateValidationError
 from orchestra.models import Task
 from orchestra.models import Todo


### PR DESCRIPTION
This PR fixes the slack notifications when todos are updated or added. 

Bug explanation:

- [create_todos API](https://github.com/b12io/orchestra/blob/main/orchestra/orchestra_api.py#L90) allows users to pass a list of new todos to create using [TodoBulkCreateListSerializer](https://github.com/b12io/orchestra/blob/main/orchestra/todos/serializers.py). This means that serializer data passed to [perform_create](https://github.com/b12io/orchestra/pull/765/files#diff-b3ed3eee712816634431297ca7826a7238d5888c41fdcc270f6666939de16996R194) function can be a list of Todo objects as well. The old code did not handle this scenario.
- The same issue happens with the `perform_update` function where the serializer can have a list of updated todos. Additionally, the line `old_todo = self.get_object()` returned the same data object after we saved the todo. We need to call this object before saving the serializer. Due to these issues, the update slack message was not going out.