### PR TITLE
Fix dashboard to handle todo sections with empty strings as null value

### DIFF
--- a/orchestra/utils/task_lifecycle.py
+++ b/orchestra/utils/task_lifecycle.py
@@ -542,7 +542,7 @@ def tasks_assigned_to_worker(worker):
     tasks_assigned = []
     time_now = timezone.now()
     pending_todos_filter = Q(status=Todo.Status.PENDING.value)
-    non_template_todo_filter = Q(template=None)
+    non_template_todo_filter = Q(template__isnull=True)
     no_section_todo_filter = Q(section__isnull=True) | Q(section='')
     for state, task_assignments in iter(task_assignments_overview.items()):
         for task_assignment in task_assignments:

--- a/orchestra/utils/task_lifecycle.py
+++ b/orchestra/utils/task_lifecycle.py
@@ -543,7 +543,7 @@ def tasks_assigned_to_worker(worker):
     time_now = timezone.now()
     pending_todos_filter = Q(status=Todo.Status.PENDING.value)
     non_template_todo_filter = Q(template=None)
-    null_section_todo_filter = Q(section__isnull=True) | Q(section='')
+    no_section_todo_filter = Q(section__isnull=True) | Q(section='')
     for state, task_assignments in iter(task_assignments_overview.items()):
         for task_assignment in task_assignments:
             step = task_assignment.task.step

--- a/orchestra/utils/task_lifecycle.py
+++ b/orchestra/utils/task_lifecycle.py
@@ -605,7 +605,7 @@ def tasks_assigned_to_worker(worker):
                     task_assignment.task.todos
                     .filter(
                         non_template_todo_filter &
-                        null_section_todo_filter
+                        no_section_todo_filter
                     ).count())
                 # If a task has no todos (complete or incomplete)
                 # assigned to it, then by default the task would be

--- a/orchestra/utils/task_lifecycle.py
+++ b/orchestra/utils/task_lifecycle.py
@@ -560,7 +560,7 @@ def tasks_assigned_to_worker(worker):
                     .filter(
                         pending_todos_filter &
                         non_template_todo_filter &
-                        null_section_todo_filter
+                        no_section_todo_filter
                     ).annotate(
                         todo_order=Case(
                             When(


### PR DESCRIPTION
This PR fixes the next todo logic in Orchestra dashboard to properly handle todos where section is set to `""` instead of null. This PR we treat the section value as null or empty.