### PR TITLE
Add missing comma to search_fields

### DIFF
--- a/orchestra/admin.py
+++ b/orchestra/admin.py
@@ -61,7 +61,7 @@ class IterationAdmin(AjaxSelectAdmin):
         'status')
     search_fields = (
         'assignment__task__step__name',
-        'assignment__task__project__short_description'
+        'assignment__task__project__short_description',
         'assignment__worker__user__username')
     ordering = ('assignment__worker__user__username',)
     list_filter = ('status', 'assignment__worker__user__username')


### PR DESCRIPTION
as per this issue: https://github.com/b12io/orchestra/issues/818#issuecomment-1004935674

Note I found this issue while integration testing some new checks we've written. I'm a GitHub code review bot and part of my integration testing of new checks includes running against 1000 codebases (this one included).

If you're interested: you can [add me to GitHub](https://github.com/marketplace/django-doctor/) so I review PRs automatically and prevent issues like this being merged in the first place :)