### PR TITLE
Remove deprecation warnings (staticfiles, logger.warn) ahead of Django 3.0 upgrade

### DIFF
--- a/orchestra/templates/accounts/availability_settings.html
+++ b/orchestra/templates/accounts/availability_settings.html
@@ -1,5 +1,5 @@
 {% extends "orchestra/base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load widget_tweaks %}
 
 {% block title %}Availability Settings{% endblock %}

--- a/orchestra/templates/accounts/communication_preferences_settings.html
+++ b/orchestra/templates/accounts/communication_preferences_settings.html
@@ -1,5 +1,5 @@
 {% extends "orchestra/base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load widget_tweaks %}
 
 {% block title %}Communication Preference Settings{% endblock %}

--- a/orchestra/templates/accounts/settings.html
+++ b/orchestra/templates/accounts/settings.html
@@ -1,5 +1,5 @@
 {% extends "orchestra/base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load widget_tweaks %}
 
 {% block title %}Account Settings{% endblock %}

--- a/orchestra/templates/admin/inc/extrastyle.html
+++ b/orchestra/templates/admin/inc/extrastyle.html
@@ -1,2 +1,2 @@
-{% load staticfiles %}
+{% load static %}
 <link rel="stylesheet" type="text/css" href="{% static 'orchestra/admin/css/orchestra_admin.css' %}">

--- a/orchestra/templates/communication/available_staffing_requests.html
+++ b/orchestra/templates/communication/available_staffing_requests.html
@@ -1,5 +1,5 @@
 {% extends 'orchestra/base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %} Available Tasks {% endblock %}
 

--- a/orchestra/templates/communication/staffing_request_accepted.html
+++ b/orchestra/templates/communication/staffing_request_accepted.html
@@ -1,5 +1,5 @@
 {% extends 'orchestra/base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if response.is_winner %}

--- a/orchestra/templates/communication/staffing_request_rejected.html
+++ b/orchestra/templates/communication/staffing_request_rejected.html
@@ -1,5 +1,5 @@
 {% extends 'orchestra/base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Thank you{% endblock %}
 

--- a/orchestra/templates/communication/staffing_response_not_permitted.html
+++ b/orchestra/templates/communication/staffing_response_not_permitted.html
@@ -1,5 +1,5 @@
 {% extends 'orchestra/base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
 Task cannot be rejected.

--- a/orchestra/templates/orchestra/base.html
+++ b/orchestra/templates/orchestra/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load hijack_tags %}
 
 <!DOCTYPE html>

--- a/orchestra/templates/orchestra/import_todo_list_template_from_spreadsheet.html
+++ b/orchestra/templates/orchestra/import_todo_list_template_from_spreadsheet.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% load admin_static %}
+{% load static %}
 {% load admin_urls %}
 
 {% block content %}

--- a/orchestra/templates/orchestra/index.html
+++ b/orchestra/templates/orchestra/index.html
@@ -1,5 +1,5 @@
 {% extends 'orchestra/base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Dashboard{% endblock %}
 

--- a/orchestra/templates/registration/activate.html
+++ b/orchestra/templates/registration/activate.html
@@ -1,5 +1,5 @@
 {% extends 'orchestra/base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Activate{% endblock %}
 

--- a/orchestra/templates/registration/password_change_form.html
+++ b/orchestra/templates/registration/password_change_form.html
@@ -1,6 +1,6 @@
 {% extends "registration/registration_base.html" %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load widget_tweaks %}
 
 {% block title %}{% trans "Change password" %}{% endblock %}

--- a/orchestra/templates/registration/registration_base.html
+++ b/orchestra/templates/registration/registration_base.html
@@ -1,5 +1,5 @@
 {% extends 'orchestra/base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block main %}
 <div id="login-page">

--- a/orchestra/workflow/load.py
+++ b/orchestra/workflow/load.py
@@ -212,7 +212,7 @@ def _verify_dependencies_not_updated(step_data, dependency_attr,
             'Drop and recreate the database to reset, or create a new '
             'version for your workflow.')
     if new_set != old_set:
-        logger.warn(
+        logger.warning(
             ('Step `%s` changed dependencies from %s to %s. You '
              'will manually have to re-run task creation logic if you '
              'want existing projects to receive new tasks.'),


### PR DESCRIPTION
Testing
* `python3 -Wa manage.py test orchestra >test-orchestra.log 2>test-orchestra.log`
* `grep Warning test-orchestra.log`
* Address relevant warnings
* Smoke test Orchestra by clicking around the experience.